### PR TITLE
feat(settings): implement nav-style toggle

### DIFF
--- a/src/components/core/nav.tsx
+++ b/src/components/core/nav.tsx
@@ -28,6 +28,7 @@ const Nav: React.FC<NavProps> = ({ home, searchBar }) => {
    const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
    const [isSettingsOpen, setIsSettingsOpen] = useState(false);
    const { user, signedIn } = useAuth();
+   const { navStyle } = useUIStateContext();
 
    useEffect(() => {
       if (!isMdUp) {
@@ -41,7 +42,7 @@ const Nav: React.FC<NavProps> = ({ home, searchBar }) => {
 
    return (
       <>
-         <Box
+         <div
             className={
                isMdUp
                   ? `${home ? "nav" : "nav-dash"} ${
@@ -49,6 +50,13 @@ const Nav: React.FC<NavProps> = ({ home, searchBar }) => {
                     }`
                   : `${home ? "nav" : "nav-dash"}`
             }
+            style={{
+               background: home
+                  ? undefined
+                  : isDark
+                  ? "rgba(1, 0, 1, 0.8)"
+                  : "rgba(250, 250, 250, 0.8)"
+            }}
          >
             {/* Menu Icon */}
             <div
@@ -132,7 +140,7 @@ const Nav: React.FC<NavProps> = ({ home, searchBar }) => {
                   </a>
                </div>
             )}
-         </Box>
+         </div>
       </>
    );
 };

--- a/src/components/dashboard/dashboardNav.tsx
+++ b/src/components/dashboard/dashboardNav.tsx
@@ -7,7 +7,6 @@ import {
    useTheme,
    IconButton,
    Link,
-   useMediaQuery,
 } from "@mui/material";
 import { Link as RouterLink } from "react-router-dom";
 import {
@@ -25,9 +24,10 @@ import {
    Cube,
    FileArrowUp,
    CaretDoubleLeft,
-   MagnifyingGlass
+   MagnifyingGlass,
 } from "phosphor-react";
 import Logo from "../../assets/images/logo.svg";
+import { useUIStateContext } from "../../contexts/UIStateContextProvider";
 
 const iconMap: Record<string, React.ComponentType<any>> = {
    House,
@@ -173,8 +173,21 @@ interface SideNavProps {
 export default function SideNav({ navOpen, setNavOpen }: SideNavProps) {
    const theme = useTheme();
    const isDark = theme.palette.mode === "dark";
-   const bgColor = isDark ? theme.palette.grey[900] : theme.palette.grey[50];
    const textColor = isDark ? theme.palette.grey[100] : theme.palette.grey[800];
+   const { navStyle } = useUIStateContext();
+   let bgColor;
+
+   switch (navStyle) {
+      case "evident":
+         bgColor = "#121621";
+         break;
+      case "blend-in":
+         bgColor = isDark ? "#121212" : "#fff";
+         break;
+      case "discrete":
+         bgColor = isDark ? theme.palette.grey[900] : theme.palette.grey[50];
+         break;
+   }
 
    return (
       <div
@@ -194,7 +207,6 @@ export default function SideNav({ navOpen, setNavOpen }: SideNavProps) {
                left: 0,
                overflowY: "auto",
                backgroundColor: bgColor,
-               color: textColor,
                borderRight: `1px solid ${
                   isDark ? theme.palette.grey[800] : theme.palette.grey[300]
                }`,
@@ -203,6 +215,7 @@ export default function SideNav({ navOpen, setNavOpen }: SideNavProps) {
                p: 2,
                zIndex: 1400,
                boxShadow: "0 0 10px rgba(0, 0, 0, 0.03)",
+               color: navStyle === "evident" ? "#fff" : textColor,
             }}
          >
             <Box
@@ -210,19 +223,23 @@ export default function SideNav({ navOpen, setNavOpen }: SideNavProps) {
                   display: "flex",
                   justifyContent: "space-between",
                   alignItems: "center",
-                  mb: 2,
+                  mb: 4,
+                  mt: 1.5,
                }}
             >
                <Link href="/dashboard" style={{ cursor: "pointer" }}>
-                  <Box sx={{ display: "flex", alignItems: "center" }}>
-                     <img src={Logo} alt="Logo" />
-                     <Typography variant="h6" fontWeight="bold">
+                  <Box sx={{ display: "flex", alignItems: "flex-start", justifyContent: "center" }}>
+                     <img src={Logo} alt="Logo" width="40" height="40" />
+                     <Typography variant="h5" fontWeight="bold">
                         Fulcrums
                      </Typography>
                   </Box>
                </Link>
                <IconButton onClick={() => setNavOpen(!navOpen)}>
-                  <CaretDoubleLeft size={20} />
+                  <CaretDoubleLeft
+                     size={20}
+                     color={navStyle === "evident" || isDark ? "#fff" : "#000"}
+                  />
                </IconButton>
             </Box>
 
@@ -293,7 +310,7 @@ function NavGroup({ group }: { group: NavGroupType }) {
                   sx={{
                      borderLeft: (theme) =>
                         `2px solid ${theme.palette.divider}`,
-                     pl: 2.5, 
+                     pl: 2.5,
                   }}
                >
                   <Stack
@@ -335,7 +352,10 @@ function NavSubItem({
                }),
             }}
          >
-            <Typography variant="body2" sx={{ fontWeight: 500, cursor: "pointer" }}>
+            <Typography
+               variant="body2"
+               sx={{ fontWeight: 500, cursor: "pointer" }}
+            >
                {sub.title}
             </Typography>
             {sub.external && (

--- a/src/components/dashboard/settings/Appearance.tsx
+++ b/src/components/dashboard/settings/Appearance.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { useState, useEffect } from "react";
 import {
    Card,
    CardContent,
@@ -9,98 +9,217 @@ import {
    Stack,
    Typography,
 } from "@mui/material";
-import { Moon as MoonIcon, Sun as SunIcon } from "phosphor-react";
+import {
+   Moon as MoonIcon,
+   Sun as SunIcon,
+   Drop,
+   Rectangle,
+   BracketsAngle,
+} from "phosphor-react";
+import { useUIStateContext } from "../../../contexts/UIStateContextProvider";
 
-export function ThemeSwitch({isDark}: any) {
+const options = [
+   {
+      title: "融合",
+      description: "与页面背景融合",
+      value: "blend-in",
+      icon: Drop,
+   },
+   {
+      title: "明显",
+      description: "推荐在暗环境下使用，导航栏颜色固定",
+      value: "evident",
+      icon: Rectangle,
+   },
+   {
+      title: "离散",
+      description: "自动适应系统主题，具备边界轮廓",
+      value: "discrete",
+      icon: BracketsAngle,
+   },
+];
+
+export function ThemeSwitch({ isDark }: any) {
+   const { setNavStyle, navStyle } = useUIStateContext();
+
+   useEffect(() => {
+      localStorage.setItem("nav-style", navStyle);
+   }, [navStyle]);
+
    return (
-      <Card
-         sx={{
-            borderRadius: 4,
-            boxShadow: "0 2px 12px rgba(0, 0, 0, 0.1)",
-            p: 1.6,
-            bgcolor: isDark ? "#1d1c1f" : "#faf8f5",
-         }}
-      >
-         <CardHeader
-            title={
-               <Typography
-                  variant="h6"
-                  sx={{
-                     fontSize: { xs: "1.6rem", sm: "2rem" },
-                     fontWeight: 600,
-                     paddingBottom: 0,
-                  }}
-               >
-                  主题选项
-               </Typography>
-            }
-         />
-         <CardContent sx={{ p: 2 }}>
-            <Card variant="outlined" sx={{ borderRadius: 4 }}>
-               <RadioGroup
-                  defaultValue="light"
-                  sx={{
-                     gap: 0,
-                     bgcolor: isDark ? "#1d1c1f" : "#f0eee6",
-                     "& .MuiFormControlLabel-root": {
-                        justifyContent: "space-between",
-                        p: 3,
-                        "&:not(:last-of-type)": {
-                           borderBottom: "1px solid var(--mui-palette-divider)",
+      <>
+         <Card
+            sx={{
+               borderRadius: 4,
+               boxShadow: "0 2px 12px rgba(0, 0, 0, 0.1)",
+               p: 1.6,
+               bgcolor: isDark ? "#1d1c1f" : "#faf8f5",
+            }}
+         >
+            <CardHeader
+               title={
+                  <Typography
+                     variant="h6"
+                     sx={{
+                        fontSize: { xs: "1.6rem", sm: "2rem" },
+                        fontWeight: 600,
+                        paddingBottom: 0,
+                     }}
+                  >
+                     主题选项
+                  </Typography>
+               }
+            />
+            <CardContent sx={{ p: 2 }}>
+               <Card variant="outlined" sx={{ borderRadius: 4 }}>
+                  <RadioGroup
+                     defaultValue="light"
+                     sx={{
+                        gap: 0,
+                        bgcolor: isDark ? "#1d1c1f" : "#f0eee6",
+                        "& .MuiFormControlLabel-root": {
+                           justifyContent: "space-between",
+                           p: 3,
+                           "&:not(:last-of-type)": {
+                              borderBottom:
+                                 "1px solid var(--mui-palette-divider)",
+                           },
                         },
-                     },
-                  }}
-               >
-                  {[
-                     {
-                        title: "亮色模式",
-                        description: "适用于明亮环境",
-                        value: "light",
-                        icon: SunIcon,
-                     },
-                     {
-                        title: "暗色模式",
-                        description: "推荐在暗环境下使用",
-                        value: "dark",
-                        icon: MoonIcon,
-                     },
-                     {
-                        title: "系统默认",
-                        description: "自动适应设备主题",
-                        value: "system",
-                        icon: SunIcon,
-                     },
-                  ].map((option) => (
-                     <FormControlLabel
-                        control={<Radio />}
-                        key={option.value}
-                        label={
-                           <Stack
-                              direction="row"
-                              spacing={2}
-                              sx={{ alignItems: "center" }}
-                           >
-                              <option.icon fontSize="var(--Icon-fontSize)" />
-                              <div>
-                                 <Typography variant="inherit">
-                                    {option.title}
-                                 </Typography>
-                                 <Typography
-                                    color="text.secondary"
-                                    variant="caption"
+                     }}
+                  >
+                     {[
+                        {
+                           title: "亮色模式",
+                           description: "适用于明亮环境",
+                           value: "light",
+                           icon: SunIcon,
+                        },
+                        {
+                           title: "暗色模式",
+                           description: "推荐在暗环境下使用",
+                           value: "dark",
+                           icon: MoonIcon,
+                        },
+                        {
+                           title: "系统默认",
+                           description: "自动适应设备主题",
+                           value: "system",
+                           icon: SunIcon,
+                        },
+                     ].map((option) => (
+                        <FormControlLabel
+                           control={<Radio />}
+                           key={option.value}
+                           label={
+                              <Stack
+                                 direction="row"
+                                 spacing={2}
+                                 sx={{ alignItems: "center" }}
+                              >
+                                 <option.icon fontSize="var(--Icon-fontSize)" />
+                                 <div>
+                                    <Typography variant="inherit">
+                                       {option.title}
+                                    </Typography>
+                                    <Typography
+                                       color="text.secondary"
+                                       variant="caption"
+                                    >
+                                       {option.description}
+                                    </Typography>
+                                 </div>
+                              </Stack>
+                           }
+                           labelPlacement="start"
+                           value={option.value}
+                        />
+                     ))}
+                  </RadioGroup>
+               </Card>
+            </CardContent>
+         </Card>
+
+         <Card
+            sx={{
+               borderRadius: 4,
+               boxShadow: "0 2px 12px rgba(0, 0, 0, 0.1)",
+               p: 1.6,
+               bgcolor: isDark ? "#1d1c1f" : "#faf8f5",
+            }}
+         >
+            <CardHeader
+               title={
+                  <Typography
+                     variant="h6"
+                     sx={{
+                        fontSize: { xs: "1.6rem", sm: "2rem" },
+                        fontWeight: 600,
+                        paddingBottom: 0,
+                     }}
+                  >
+                     导航栏风格
+                  </Typography>
+               }
+            />
+            <CardContent sx={{ p: 2 }}>
+               <Card variant="outlined" sx={{ borderRadius: 4 }}>
+                  <RadioGroup
+                     name="nav-style"
+                     value={navStyle}
+                     onChange={(_, newValue) => {
+                        const v = newValue as
+                           | "blend-in"
+                           | "evident"
+                           | "discrete";
+                        setNavStyle(v);
+                     }}
+                     sx={{
+                        gap: 0,
+                        bgcolor: "#f0eee6",
+                        "& .MuiFormControlLabel-root": {
+                           justifyContent: "space-between",
+                           p: 3,
+                           "&:not(:last-of-type)": {
+                              borderBottom:
+                                 "1px solid var(--mui-palette-divider)",
+                           },
+                        },
+                     }}
+                  >
+                     {options.map(
+                        ({ title, description, value, icon: Icon }) => (
+                           <FormControlLabel
+                              key={value}
+                              value={value}
+                              control={<Radio />}
+                              label={
+                                 <Stack
+                                    direction="row"
+                                    spacing={2}
+                                    sx={{ alignItems: "center" }}
                                  >
-                                    {option.description}
-                                 </Typography>
-                              </div>
-                           </Stack>
-                        }
-                        labelPlacement="start"
-                        value={option.value}
-                     />
-                  ))}
-               </RadioGroup>
-            </Card>
-         </CardContent>
-      </Card>
+                                    <Icon fontSize="var(--Icon-fontSize)" />
+                                    <div>
+                                       <Typography variant="inherit">
+                                          {title}
+                                       </Typography>
+                                       <Typography
+                                          color="text.secondary"
+                                          variant="caption"
+                                       >
+                                          {description}
+                                       </Typography>
+                                    </div>
+                                 </Stack>
+                              }
+                              labelPlacement="start"
+                           />
+                        )
+                     )}
+                  </RadioGroup>
+               </Card>
+            </CardContent>
+         </Card>
+      </>
    );
 }

--- a/src/contexts/UIStateContextProvider.tsx
+++ b/src/contexts/UIStateContextProvider.tsx
@@ -4,10 +4,8 @@ import React, {
    useMemo,
    useState,
    ReactNode,
-   useEffect,
 } from "react";
 import { useMediaQuery, useTheme } from "@mui/material";
-import { m } from "react-router/dist/development/fog-of-war-Cm1iXIp7";
 
 interface UIStateContextProps {
    isModalOpen: boolean;

--- a/src/contexts/UIStateContextProvider.tsx
+++ b/src/contexts/UIStateContextProvider.tsx
@@ -7,6 +7,7 @@ import React, {
    useEffect,
 } from "react";
 import { useMediaQuery, useTheme } from "@mui/material";
+import { m } from "react-router/dist/development/fog-of-war-Cm1iXIp7";
 
 interface UIStateContextProps {
    isModalOpen: boolean;
@@ -16,6 +17,10 @@ interface UIStateContextProps {
    setOverlay: React.Dispatch<React.SetStateAction<boolean>>;
    closeOverlay: () => void;
    mainContentStyles: (navOpen: boolean) => object;
+   navStyle: string;
+   setNavStyle: React.Dispatch<
+      React.SetStateAction<"blend-in" | "discrete" | "evident">
+   >;
 }
 
 const UIStateContext = createContext<UIStateContextProps | undefined>(
@@ -34,6 +39,14 @@ export const UIStateContextProvider: React.FC<UIStateContextProviderProps> = ({
    const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
    const [navOpen, setNavOpen] = useState<boolean>(isMdUp);
    const [overlay, setOverlay] = useState<boolean>(!isMdUp);
+   const [navStyle, setNavStyle] = useState<
+      "blend-in" | "evident" | "discrete"
+   >(() => {
+      const saved = localStorage.getItem("nav-style");
+      return saved === "blend-in" || saved === "evident" || saved === "discrete"
+         ? saved
+         : "blend-in";
+   });
 
    const closeOverlay = () => {
       setOverlay(false);
@@ -58,8 +71,10 @@ export const UIStateContextProvider: React.FC<UIStateContextProviderProps> = ({
          setOverlay,
          closeOverlay,
          mainContentStyles,
+         navStyle,
+         setNavStyle,
       }),
-      [isModalOpen, navOpen, overlay]
+      [isModalOpen, navOpen, overlay, mainContentStyles, navStyle]
    );
 
    return (

--- a/src/pages/dashboard/settingsPage.tsx
+++ b/src/pages/dashboard/settingsPage.tsx
@@ -23,7 +23,7 @@ const SettingPage = () => {
       <Box className="recent-products-page" sx={mainContentStyles(navOpen)}>
          <SideNav navOpen={navOpen} setNavOpen={setNavOpen} />
 
-         <Nav home={false} searchBar={false} />
+         <Nav home={false} searchBar={true} />
 
          <div className="title-recent">
             <Typography

--- a/src/styles/nav.css
+++ b/src/styles/nav.css
@@ -20,12 +20,12 @@
    width: 90%;
    max-width: 1000px;
    padding: 10px 12px;
-   background: rgba(208, 208, 208, 0.1);
-   backdrop-filter: blur(12px);
+   backdrop-filter: blur(10px);
    border-radius: 40px;
    z-index: 100;
    transition: all 0.2s all;
-   box-shadow: 0 4px 17px rgba(0, 0, 0, 0.1);
+   box-shadow: 0 4px 17px rgba(0, 0, 0, 0.1) !important;
+   background: rgba(208, 208, 208, 0.1);
 }
 
 .nav-logo {
@@ -58,7 +58,7 @@
    }
    .nav-logo p {
       font-size: 1.1rem !important;
-   }  
+   }
    .cta-btn-join-nav {
       padding: 6px 15px;
       background-color: var(--background-color) !important;
@@ -71,14 +71,14 @@
 }
 
 .cta-btn-join-nav {
-      padding: 7px 20px;
-      background-color: var(--background-color) !important;
-      color: var(--text-secondary-color) !important;
-      font-weight: 500;
-      font-size: 0.9rem;
-      border: none;
-      border-radius: 40px;
-   }
+   padding: 7px 20px;
+   background-color: var(--background-color) !important;
+   color: var(--text-secondary-color) !important;
+   font-weight: 500;
+   font-size: 0.9rem;
+   border: none;
+   border-radius: 40px;
+}
 
 .nav-logo img {
    height: 40px;
@@ -198,8 +198,7 @@ button:active {
    gap: 3px;
    width: 100%;
    padding: 12px 16px;
-   background: rgba(194, 194, 194, 0.1);
-   backdrop-filter: blur(10px);
+   backdrop-filter: blur(20px);
    z-index: 1000;
    transition: all 0.2s all;
    box-shadow: 0 3px 10px rgba(0, 0, 0, 0.06);


### PR DESCRIPTION

## What
- Persist nav‑style choice across the app
- Add new RadioGroup UI in Settings panel
- Store selection in Context + localStorage

## Why
Users needed a way to switch between blend‑in, evident, and discrete nav styles and have it persist.

## Testing
- Manually toggled each style and verified SideNav background updates
- Confirmed value is saved in localStorage and restored on reload

closes #4
