### PR TITLE
Adds offline‑first support with Dexie.js + a cloud‑function sync pipeline.

### DIFF
--- a/backend/functions/src/index.ts
+++ b/backend/functions/src/index.ts
@@ -35,6 +35,8 @@ import { addSupplier } from "./services/supplier/addSupplier";
 import { editSupplier } from "./services/supplier/editSupplier";
 import { deleteSupplier } from "./services/supplier/deleteSupplier";
 
+import { syncAll } from "./services/syncAll";
+
 export {
    createUserDoc,
    createProduct,
@@ -47,6 +49,7 @@ export {
    addSupplier,
    editSupplier,
    deleteSupplier,
+   syncAll,
 };
 
 // Start writing functions

--- a/backend/functions/src/services/lib/upload_blob_as_jpg.ts
+++ b/backend/functions/src/services/lib/upload_blob_as_jpg.ts
@@ -3,24 +3,59 @@ import * as functions from "firebase-functions/v2";
 
 const bucket = admin.storage().bucket();
 
-export async function uploadBlobAsJPG(image: any, token: string, path: string) {
-   const file = bucket.file(path);
-   const buffer = Buffer.from(image, "base64");      
+function parseBase64Image(input: string): { mime: string; data: string } {
+   const match = input.match(/^data:(image\/[a-z]+);base64,(.+)$/i);
+   if (match) {
+      return {
+         mime: match[1],
+         data: match[2].replace(/\s/g, ""),
+      };
+   }
 
+   // Assume raw base64 string and default to jpeg this is going to corrupt the file if png so front end make sure to send mime
+   return {
+      mime: "image/jpeg",
+      data: input.replace(/\s/g, ""),
+   };
+}
+
+export async function uploadBlobAsJPG(
+   imageInput: string,
+   token: string,
+   path: string
+): Promise<string> {
    try {
+      const { mime, data } = parseBase64Image(imageInput);
+      const buffer = Buffer.from(data, "base64");
+
+      if (buffer.length === 0) {
+         throw new functions.https.HttpsError(
+            "invalid-argument",
+            "Image buffer is empty"
+         );
+      }
+
+      const file = bucket.file(path);
+
       await file.save(buffer, {
          metadata: {
-            contentType: "image/jpeg",
+            contentType: mime,
             metadata: {
                firebaseStorageDownloadTokens: token,
             },
          },
       });
 
-      const publicUrl = `https://firebasestorage.googleapis.com/v0/b/${bucket.name}/o/${path}?alt=media&token=${token}`;
+      const publicUrl = `https://firebasestorage.googleapis.com/v0/b/${
+         bucket.name
+      }/o/${encodeURIComponent(path)}?alt=media&token=${token}`;
 
       return publicUrl;
-   } catch {
-      throw new functions.https.HttpsError("internal", "Failed to upload photo");
+   } catch (err) {
+      console.error("Image upload failed:", err);
+      throw new functions.https.HttpsError(
+         "internal",
+         "Failed to upload image"
+      );
    }
 }

--- a/backend/functions/src/services/syncAll.ts
+++ b/backend/functions/src/services/syncAll.ts
@@ -1,0 +1,87 @@
+import * as functions from "firebase-functions/v2";
+import * as admin from "firebase-admin";
+import { FieldValue } from "firebase-admin/firestore";
+import { uploadBlobAsJPG } from "./lib/upload_blob_as_jpg";
+import { Supplier, Clients, Product } from "../types/types";
+
+const db = admin.firestore();
+
+interface SyncPayload {
+   suppliers: Supplier[];
+   clients: Clients[];
+   products: Product[];
+}
+
+export const syncAll = functions.https.onCall(
+   async (req: functions.https.CallableRequest) => {
+      if (!req.auth) {
+         throw new functions.https.HttpsError("unauthenticated", "请先登录");
+      }
+      const uid = req.auth.uid;
+
+      const { suppliers, clients, products } = req.data as SyncPayload;
+
+      if (
+         suppliers.length > 50 ||
+         clients.length > 50 ||
+         products.length > 120
+      ) {
+         throw new functions.https.HttpsError(
+            "invalid-argument",
+            "超过批量上限：最多 50 供应商 / 50 客户 / 120 产品"
+         );
+      }
+
+      const userRef = db.collection("users").doc(uid);
+      const supplierCol = userRef.collection("suppliers");
+      const clientCol = userRef.collection("clients");
+      const productCol = userRef.collection("products");
+
+      const writer = db.bulkWriter();
+
+      suppliers.forEach((s) =>
+         writer.set(supplierCol.doc(s.supplierId), s, { merge: true })
+      );
+
+      clients.forEach((c) =>
+         writer.set(clientCol.doc(c.clientId), c, { merge: true })
+      );
+
+      await writer.close(); 
+
+      for (const p of products) {
+         const prodRef = productCol.doc(p.productId || undefined);
+         const productId = prodRef.id;
+
+         let imageUrl = p.image;
+         const b64 = p.image;
+
+         if (b64) {
+            const imagePath = `users/${uid}/products/${productId}.jpg`;
+            imageUrl = await uploadBlobAsJPG(b64, productId, imagePath);
+         }
+
+         const productData = { ...p, image: imageUrl, productId };
+         await prodRef.set(productData, { merge: true });
+
+         await supplierCol
+            .doc(p.supplierId)
+            .set(
+               { productIds: FieldValue.arrayUnion(productId) },
+               { merge: true }
+            );
+
+         const clientBatches = p.clients.map((cid) =>
+            clientCol
+               .doc(cid)
+               .set(
+                  { productIds: FieldValue.arrayUnion(productId) },
+                  { merge: true }
+               )
+         );
+         await Promise.all(clientBatches);
+      }
+
+      return { success: true };
+   }
+);

--- a/backend/functions/src/types/types.ts
+++ b/backend/functions/src/types/types.ts
@@ -60,26 +60,3 @@ export type Clients = {
    productIds: string[];
    updatedAt: string;
 };
-
-export type UserType = {
-   createdAt: string;
-   name: string | null;
-   email: string | null;
-   photo: string | null;
-   role: string | "user";
-   uid: string | null;
-};
-
-export type AuthContextType = {
-   user: UserType | null;
-   loading: boolean;
-   setUser: React.Dispatch<React.SetStateAction<UserType | null>>;
-   setLoading: React.Dispatch<React.SetStateAction<boolean>>;
-   signedIn: boolean;
-};
-
-export type SyncPayload = {
-   products: Product[];
-   suppliers: Supplier[];
-   clients: Clients[];
-};

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
             "@types/recharts": "^1.8.29",
             "@vercel/analytics": "^1.5.0",
             "dayjs": "^1.11.13",
+            "dexie": "^4.0.11",
             "firebase": "^11.3.0",
             "pdf-lib": "^1.17.1",
             "phosphor-react": "^1.4.1",
@@ -24,6 +25,7 @@
             "react-router": "^7.1.5",
             "react-router-dom": "^7.1.5",
             "recharts": "^2.15.1",
+            "uuid": "^11.1.0",
             "vercel": "^41.2.0"
          },
          "devDependencies": {
@@ -3513,6 +3515,11 @@
             "node": ">=8"
          }
       },
+      "node_modules/dexie": {
+         "version": "4.0.11",
+         "resolved": "https://registry.npmjs.org/dexie/-/dexie-4.0.11.tgz",
+         "integrity": "sha512-SOKO002EqlvBYYKQSew3iymBoN2EQ4BDw/3yprjh7kAfFzjBYkaMNa/pZvcA7HSWlcKSQb9XhPe3wKyQ0x4A8A=="
+      },
       "node_modules/diff": {
          "version": "4.0.2",
          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
@@ -5824,6 +5831,18 @@
          "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
          "dependencies": {
             "punycode": "^2.1.0"
+         }
+      },
+      "node_modules/uuid": {
+         "version": "11.1.0",
+         "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+         "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+         "funding": [
+            "https://github.com/sponsors/broofa",
+            "https://github.com/sponsors/ctavan"
+         ],
+         "bin": {
+            "uuid": "dist/esm/bin/uuid"
          }
       },
       "node_modules/v8-compile-cache-lib": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
             "dexie": "^4.0.11",
             "dexie-react-hooks": "^1.1.7",
             "firebase": "^11.3.0",
+            "gsap": "^3.13.0",
             "pdf-lib": "^1.17.1",
             "phosphor-react": "^1.4.1",
             "react": "^18.2.0",
@@ -4290,6 +4291,11 @@
          "version": "4.2.11",
          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
          "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
+      },
+      "node_modules/gsap": {
+         "version": "3.13.0",
+         "resolved": "https://registry.npmjs.org/gsap/-/gsap-3.13.0.tgz",
+         "integrity": "sha512-QL7MJ2WMjm1PHWsoFrAQH/J8wUeqZvMtHO58qdekHpCfhvhSL4gSiz6vJf5EeMP0LOn3ZCprL2ki/gjED8ghVw=="
       },
       "node_modules/hasown": {
          "version": "2.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
             "@vercel/analytics": "^1.5.0",
             "dayjs": "^1.11.13",
             "dexie": "^4.0.11",
+            "dexie-react-hooks": "^1.1.7",
             "firebase": "^11.3.0",
             "pdf-lib": "^1.17.1",
             "phosphor-react": "^1.4.1",
@@ -3519,6 +3520,16 @@
          "version": "4.0.11",
          "resolved": "https://registry.npmjs.org/dexie/-/dexie-4.0.11.tgz",
          "integrity": "sha512-SOKO002EqlvBYYKQSew3iymBoN2EQ4BDw/3yprjh7kAfFzjBYkaMNa/pZvcA7HSWlcKSQb9XhPe3wKyQ0x4A8A=="
+      },
+      "node_modules/dexie-react-hooks": {
+         "version": "1.1.7",
+         "resolved": "https://registry.npmjs.org/dexie-react-hooks/-/dexie-react-hooks-1.1.7.tgz",
+         "integrity": "sha512-Lwv5W0Hk+uOW3kGnsU9GZoR1er1B7WQ5DSdonoNG+focTNeJbHW6vi6nBoX534VKI3/uwHebYzSw1fwY6a7mTw==",
+         "peerDependencies": {
+            "@types/react": ">=16",
+            "dexie": "^3.2 || ^4.0.1-alpha",
+            "react": ">=16"
+         }
       },
       "node_modules/diff": {
          "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
       "@vercel/analytics": "^1.5.0",
       "dayjs": "^1.11.13",
       "dexie": "^4.0.11",
+      "dexie-react-hooks": "^1.1.7",
       "firebase": "^11.3.0",
       "pdf-lib": "^1.17.1",
       "phosphor-react": "^1.4.1",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
       "dexie": "^4.0.11",
       "dexie-react-hooks": "^1.1.7",
       "firebase": "^11.3.0",
+      "gsap": "^3.13.0",
       "pdf-lib": "^1.17.1",
       "phosphor-react": "^1.4.1",
       "react": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
       "@types/recharts": "^1.8.29",
       "@vercel/analytics": "^1.5.0",
       "dayjs": "^1.11.13",
+      "dexie": "^4.0.11",
       "firebase": "^11.3.0",
       "pdf-lib": "^1.17.1",
       "phosphor-react": "^1.4.1",
@@ -25,6 +26,7 @@
       "react-router": "^7.1.5",
       "react-router-dom": "^7.1.5",
       "recharts": "^2.15.1",
+      "uuid": "^11.1.0",
       "vercel": "^41.2.0"
    },
    "devDependencies": {

--- a/src/components/core/footer.tsx
+++ b/src/components/core/footer.tsx
@@ -113,6 +113,7 @@ const Footer = () => {
    return (
       <footer
          className="footer-container"
+         id="footer"
          style={{ position: "relative", paddingBottom: "25px" }}
       >
          <div className="footer">

--- a/src/components/dashboard/core/offlineDrawer.tsx
+++ b/src/components/dashboard/core/offlineDrawer.tsx
@@ -573,7 +573,7 @@ function DetailForm({ item, tab, onBack, onSave }: DetailFormProps) {
       ],
       suppliers: [
          { key: "supplierName", label: "供应商名称" },
-         { key: "supplierPhoneNumber", label: "电话", type: "number" },
+         { key: "supplierPhone", label: "电话", type: "number" },
          { key: "supplierAddress", label: "地址" },
          { key: "supplierEmail", label: "邮箱" },
       ],

--- a/src/components/dashboard/core/offlineDrawer.tsx
+++ b/src/components/dashboard/core/offlineDrawer.tsx
@@ -38,8 +38,9 @@ import {
 } from "phosphor-react";
 import { deleteRecord, db } from "../../../lib/dexieUtils";
 import getBase64FromBlobUrl from "../../../lib/blob-to-blob64";
-import { Product, Supplier, Clients } from "../../../types/types";
+import { Product, Supplier, Clients, SyncPayload } from "../../../types/types";
 import { useLiveQuery } from "dexie-react-hooks";
+import { useProductSupplierClientContext } from "../../../contexts/productSupplierClientContextProvider";
 
 /* ──────────────────────────────────────────────────────────── */
 /*  MAIN                                                        */
@@ -49,11 +50,11 @@ interface OfflineDrawerProps {
 }
 
 export function OfflineDrawer({ isOnline }: OfflineDrawerProps) {
+   const { setErrorMessages, syncState, syncAll } =
+      useProductSupplierClientContext();
+
    const [showCloud, setShowCloud] = useState(true);
    const [open, setOpen] = useState(false);
-   const [syncState, setSyncState] = useState<"idle" | "syncing" | "done">(
-      "idle"
-   );
 
    const productCount = useLiveQuery(() => db.products.count(), []);
    const supplierCount = useLiveQuery(() => db.suppliers.count(), []);
@@ -67,17 +68,27 @@ export function OfflineDrawer({ isOnline }: OfflineDrawerProps) {
       setShowCloud(true);
    }, [isOnline]);
 
-   const startSync = () => {
+   const startSync = async () => {
       if (syncState !== "idle") return;
 
-      setSyncState("syncing");
+      const [products, suppliers, clients] = await Promise.all([
+         db.products.toArray(),
+         db.suppliers.toArray(),
+         db.clients.toArray(),
+      ]);
 
-      // TODO: replace setTimeout with real sync promise
-      setTimeout(() => setSyncState("done"), 2500);
+      const payload: SyncPayload = { products, suppliers, clients };
+
+      await syncAll(payload);
    };
 
    const showSync =
       isOnline && (productCount! > 0 || supplierCount! > 0 || clientCount! > 0);
+
+   if (productCount! > 120 || supplierCount! > 50 || clientCount! > 50) {
+      setErrorMessages("产品，客户，或供应商数量以达到极限。");
+      return;
+   }
 
    return (
       <>
@@ -119,7 +130,7 @@ export function OfflineDrawer({ isOnline }: OfflineDrawerProps) {
             </Tooltip>
          )}
 
-         {!showSync && (
+         {(!showSync && !isOnline)  && (
             <Grow in>
                <Box
                   onClick={() => setOpen(true)}
@@ -152,7 +163,11 @@ export function OfflineDrawer({ isOnline }: OfflineDrawerProps) {
                      timeout={400}
                   >
                      <Box
-                        sx={{ display: "flex", alignItems: "center", gap: 0.5 }}
+                        sx={{
+                           display: "flex",
+                           alignItems: "center",
+                           gap: 0.5,
+                        }}
                      >
                         <Package size={18} weight="fill" />
                         <Typography
@@ -386,7 +401,7 @@ function EntityList<T>({
                   {avatarSrc && avatarSrc(item) && (
                      <Box
                         component="img"
-                        src={ensureDataUrl(avatarSrc(item))}
+                        src={avatarSrc(item)}
                         alt="thumb"
                         sx={{
                            width: 64,
@@ -469,17 +484,22 @@ function DetailForm({ item, tab, onBack, onSave }: DetailFormProps) {
    const handleChange = (key: string) => (e: ChangeEvent<HTMLInputElement>) =>
       saveNow(setDeep(form, key, e.target.value));
 
-   const handleFile: React.ChangeEventHandler<HTMLInputElement> = async (e) => {
+   const handleFile: React.ChangeEventHandler<HTMLInputElement> = (e) => {
       const file = e.target.files?.[0];
       if (!file) return;
 
-      const blobUrl = URL.createObjectURL(file);
-      const b64 = await getBase64FromBlobUrl(blobUrl);
-      URL.revokeObjectURL(blobUrl);
+      const reader = new FileReader();
 
-      saveNow({ ...form, image: ensureDataUrl(b64 ?? "") });
+      reader.onloadend = () => {
+         const result = reader.result;
+         if (typeof result === "string") {
+            saveNow({ ...form, image: result });
+         }
+      };
+
+      reader.readAsDataURL(file); 
    };
-
+   
    const adornmentsFor = (key: string) => {
       if (key === "unitPrice") {
          return {
@@ -638,9 +658,4 @@ function DetailForm({ item, tab, onBack, onSave }: DetailFormProps) {
          </Box>
       </Box>
    );
-}
-
-function ensureDataUrl(str?: string) {
-   if (!str) return "";
-   return str.startsWith("data:image") ? str : `data:image/png;base64,${str}`;
 }

--- a/src/components/dashboard/core/offlineDrawer.tsx
+++ b/src/components/dashboard/core/offlineDrawer.tsx
@@ -87,7 +87,7 @@ export function OfflineDrawer({ isOnline }: OfflineDrawerProps) {
 
    if (productCount! > 120 || supplierCount! > 50 || clientCount! > 50) {
       setErrorMessages("产品，客户，或供应商数量以达到极限。");
-      return;
+      return null;
    }
 
    return (

--- a/src/components/dashboard/core/offlineDrawer.tsx
+++ b/src/components/dashboard/core/offlineDrawer.tsx
@@ -26,14 +26,17 @@ import {
    Grid,
    Stack,
    InputAdornment,
+   Tooltip,
 } from "@mui/material";
 import {
    CloudSlash,
    Package,
    ArrowLeft,
    X as DeleteIcon,
+   ArrowsClockwise,
+   CheckCircle,
 } from "phosphor-react";
-import { getProductCount, deleteRecord, db } from "../../../lib/dexieUtils";
+import { deleteRecord, db } from "../../../lib/dexieUtils";
 import getBase64FromBlobUrl from "../../../lib/blob-to-blob64";
 import { Product, Supplier, Clients } from "../../../types/types";
 import { useLiveQuery } from "dexie-react-hooks";
@@ -48,8 +51,13 @@ interface OfflineDrawerProps {
 export function OfflineDrawer({ isOnline }: OfflineDrawerProps) {
    const [showCloud, setShowCloud] = useState(true);
    const [open, setOpen] = useState(false);
+   const [syncState, setSyncState] = useState<"idle" | "syncing" | "done">(
+      "idle"
+   );
 
-  const productCount = useLiveQuery(() => db.products.count(), []);
+   const productCount = useLiveQuery(() => db.products.count(), []);
+   const supplierCount = useLiveQuery(() => db.suppliers.count(), []);
+   const clientCount = useLiveQuery(() => db.clients.count(), []);
 
    useEffect(() => {
       if (!isOnline) {
@@ -59,45 +67,105 @@ export function OfflineDrawer({ isOnline }: OfflineDrawerProps) {
       setShowCloud(true);
    }, [isOnline]);
 
-   if (isOnline && !open) return null;
+   const startSync = () => {
+      if (syncState !== "idle") return;
+
+      setSyncState("syncing");
+
+      // TODO: replace setTimeout with real sync promise
+      setTimeout(() => setSyncState("done"), 2500);
+   };
+
+   const showSync =
+      isOnline && (productCount! > 0 || supplierCount! > 0 || clientCount! > 0);
 
    return (
       <>
-         <Grow in>
-            <Box
-               onClick={() => setOpen(true)}
-               sx={{
-                  position: "fixed",
-                  bottom: 16,
-                  right: 16,
-                  display: "flex",
-                  alignItems: "center",
-                  px: 1.25,
-                  py: 0.75,
-                  borderRadius: 999,
-                  boxShadow: 4,
-                  bgcolor: (t) => t.palette.background.default,
-                  cursor: "pointer",
-                  zIndex: 30,
-               }}
+         {showSync && (
+            <Tooltip
+               title={
+                  syncState === "idle"
+                     ? "同步到云端"
+                     : syncState === "syncing"
+                     ? "同步中…"
+                     : "已完成"
+               }
             >
-               <Collapse in={showCloud} orientation="horizontal" timeout={400}>
-                  <CloudSlash size={20} weight="fill" />
-               </Collapse>
+               <IconButton
+                  onClick={startSync}
+                  color={syncState === "done" ? "success" : "primary"}
+                  sx={{
+                     position: "fixed",
+                     bottom: 16,
+                     right: 16,
+                     zIndex: 40,
+                     border: "0.5px solid",
+                     bgcolor: "background.paper",
+                     animation:
+                        syncState === "syncing"
+                           ? "spin 1s linear infinite"
+                           : "none",
+                     "@keyframes spin": {
+                        to: { transform: "rotate(360deg)" },
+                     },
+                  }}
+               >
+                  {syncState === "done" ? (
+                     <CheckCircle size={26} weight="fill" />
+                  ) : (
+                     <ArrowsClockwise size={26} weight="bold" />
+                  )}
+               </IconButton>
+            </Tooltip>
+         )}
 
-               <Collapse in={!showCloud} orientation="horizontal" timeout={400}>
-                  <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
-                     <Package size={18} weight="fill" />
-                     <Typography
-                        variant="caption"
-                        sx={{ fontWeight: 700, fontSize: "0.75rem" }}
+         {!showSync && (
+            <Grow in>
+               <Box
+                  onClick={() => setOpen(true)}
+                  sx={{
+                     position: "fixed",
+                     bottom: 16,
+                     right: 16,
+                     display: "flex",
+                     alignItems: "center",
+                     px: 1.25,
+                     py: 0.75,
+                     borderRadius: 999,
+                     boxShadow: 4,
+                     bgcolor: "background.paper",
+                     cursor: "pointer",
+                     zIndex: 30,
+                  }}
+               >
+                  <Collapse
+                     in={showCloud}
+                     orientation="horizontal"
+                     timeout={400}
+                  >
+                     <CloudSlash size={20} weight="fill" />
+                  </Collapse>
+
+                  <Collapse
+                     in={!showCloud}
+                     orientation="horizontal"
+                     timeout={400}
+                  >
+                     <Box
+                        sx={{ display: "flex", alignItems: "center", gap: 0.5 }}
                      >
-                        {productCount ?? "…"}
-                     </Typography>
-                  </Box>
-               </Collapse>
-            </Box>
-         </Grow>
+                        <Package size={18} weight="fill" />
+                        <Typography
+                           variant="caption"
+                           sx={{ fontWeight: 700, fontSize: "0.75rem" }}
+                        >
+                           {productCount ?? "…"}
+                        </Typography>
+                     </Box>
+                  </Collapse>
+               </Box>
+            </Grow>
+         )}
 
          <EntityDrawer open={open} onClose={() => setOpen(false)} />
       </>
@@ -163,7 +231,7 @@ function EntityDrawer({ open, onClose }: EntityDrawerProps) {
          ModalProps={{ keepMounted: true, disableScrollLock: false }}
          PaperProps={{
             sx: {
-               height: "90vh",
+               height: "90dvh",
                borderTopLeftRadius: 16,
                borderTopRightRadius: 16,
             },
@@ -187,7 +255,7 @@ function EntityDrawer({ open, onClose }: EntityDrawerProps) {
 
          <Box
             sx={{
-               height: "90vh",
+               height: "90dvh",
                overflowY: "auto",
                p: 1.5,
                scrollbarWidth: "none",

--- a/src/components/dashboard/core/offlineDrawer.tsx
+++ b/src/components/dashboard/core/offlineDrawer.tsx
@@ -42,6 +42,36 @@ import { Product, Supplier, Clients, SyncPayload } from "../../../types/types";
 import { useLiveQuery } from "dexie-react-hooks";
 import { useProductSupplierClientContext } from "../../../contexts/productSupplierClientContextProvider";
 
+const ensureDataUrl = (b64: string) => {
+   if (!b64) return "";
+
+   if (b64.startsWith("data:image") || b64.startsWith("http")) return b64;
+
+   const signatures: { [sig: string]: string } = {
+      "/9j/": "image/jpeg",
+      iVBOR: "image/png",
+      UklGR: "image/webp",
+      AAABAA: "image/x-icon",
+      R0lGOD: "image/gif",
+      fLaC: "audio/flac",
+      SUkq: "image/tiff",
+      ftyp: "image/heic", 
+   };
+
+   const head = b64.slice(0, 16); 
+   let mime = "image/png"; 
+
+   for (const sig in signatures) {
+      if (head.includes(sig)) {
+         mime = signatures[sig];
+         break;
+      }
+   }
+
+   return `data:${mime};base64,${b64}`;
+};
+
+
 /* ──────────────────────────────────────────────────────────── */
 /*  MAIN                                                        */
 /* ──────────────────────────────────────────────────────────── */
@@ -249,6 +279,7 @@ function EntityDrawer({ open, onClose }: EntityDrawerProps) {
                height: "90dvh",
                borderTopLeftRadius: 16,
                borderTopRightRadius: 16,
+               bgcolor: "var(--background-color)",
             },
          }}
       >
@@ -260,7 +291,7 @@ function EntityDrawer({ open, onClose }: EntityDrawerProps) {
                   setView("list");
                }}
                variant="fullWidth"
-               sx={{ borderBottom: 1, borderColor: "divider", pt: 1 }}
+               sx={{ bgcolor: "var(--background-secondary-color)", pt: 1 }}
             >
                <Tab label="产品" value="products" />
                <Tab label="供应商" value="suppliers" />
@@ -275,6 +306,7 @@ function EntityDrawer({ open, onClose }: EntityDrawerProps) {
                p: 1.5,
                scrollbarWidth: "none",
                "&::-webkit-scrollbar": { display: "none" },
+               bgcolor: "var(--background-color)",
             }}
          >
             {view === "list" && (
@@ -291,7 +323,7 @@ function EntityDrawer({ open, onClose }: EntityDrawerProps) {
                               p.material ?? ""
                            }`
                         }
-                        avatarSrc={(p) => p.image}
+                        avatarSrc={(p) => ensureDataUrl(p.image)}
                         onSelect={(p) => {
                            setSelect(p);
                            setView("detail");
@@ -402,7 +434,7 @@ function EntityList<T>({
                      <Box
                         component="img"
                         src={avatarSrc(item)}
-                        alt="thumb"
+                        alt="产品"
                         sx={{
                            width: 64,
                            height: 64,
@@ -456,8 +488,6 @@ function DetailForm({ item, tab, onBack, onSave }: DetailFormProps) {
    const [form, setForm] = useState<Record<string, any>>({ ...item });
 
    /* ---------------- helpers ---------------- */
-   const ensureDataUrl = (b64: string) =>
-      b64.startsWith("data:image") ? b64 : `data:image/png;base64,${b64}`;
 
    const getDeep = (obj: any, path: string) =>
       path.split(".").reduce((acc, k) => (acc ? acc[k] : undefined), obj);

--- a/src/components/dashboard/core/offlineDrawer.tsx
+++ b/src/components/dashboard/core/offlineDrawer.tsx
@@ -1,8 +1,5 @@
 /* eslint-disable react-hooks/exhaustive-deps */
-/* ──────────────────────────────────────────────────────────── */
-/*  Offline‑indicator FAB  +  80 vh bottom drawer (Dexie)       */
-/*  Full‑field editor, image upload (base‑64), slim UI          */
-/* ──────────────────────────────────────────────────────────── */
+
 import {
    useState,
    useEffect,
@@ -26,33 +23,33 @@ import {
    TextField,
    Button,
    IconButton,
-   Avatar,
+   Grid,
+   Stack,
+   InputAdornment,
 } from "@mui/material";
-import { CloudSlash, Package, ArrowLeft } from "phosphor-react";
 import {
-   getProductCount,
-   getAllRecords,
-   updateRecord,
-   db,
-} from "../../../lib/dexieUtils";
+   CloudSlash,
+   Package,
+   ArrowLeft,
+   X as DeleteIcon,
+} from "phosphor-react";
+import { getProductCount, deleteRecord, db } from "../../../lib/dexieUtils";
 import getBase64FromBlobUrl from "../../../lib/blob-to-blob64";
 import { Product, Supplier, Clients } from "../../../types/types";
+import { useLiveQuery } from "dexie-react-hooks";
 
 /* ──────────────────────────────────────────────────────────── */
-/*  MAIN FLOATING BUTTON + DRAWER                               */
+/*  MAIN                                                        */
 /* ──────────────────────────────────────────────────────────── */
 interface OfflineDrawerProps {
    isOnline: boolean;
 }
 
 export function OfflineDrawer({ isOnline }: OfflineDrawerProps) {
-   const [count, setCount] = useState<number | null>(null);
    const [showCloud, setShowCloud] = useState(true);
    const [open, setOpen] = useState(false);
 
-   useEffect(() => {
-      getProductCount().then(setCount).catch(console.error);
-   }, []);
+  const productCount = useLiveQuery(() => db.products.count(), []);
 
    useEffect(() => {
       if (!isOnline) {
@@ -62,11 +59,10 @@ export function OfflineDrawer({ isOnline }: OfflineDrawerProps) {
       setShowCloud(true);
    }, [isOnline]);
 
-   if (isOnline) return null;
+   if (isOnline && !open) return null;
 
    return (
       <>
-         {/* FAB */}
          <Grow in>
             <Box
                onClick={() => setOpen(true)}
@@ -82,7 +78,7 @@ export function OfflineDrawer({ isOnline }: OfflineDrawerProps) {
                   boxShadow: 4,
                   bgcolor: (t) => t.palette.background.default,
                   cursor: "pointer",
-                  zIndex: 1300,
+                  zIndex: 30,
                }}
             >
                <Collapse in={showCloud} orientation="horizontal" timeout={400}>
@@ -96,7 +92,7 @@ export function OfflineDrawer({ isOnline }: OfflineDrawerProps) {
                         variant="caption"
                         sx={{ fontWeight: 700, fontSize: "0.75rem" }}
                      >
-                        {count ?? "…"}
+                        {productCount ?? "…"}
                      </Typography>
                   </Box>
                </Collapse>
@@ -109,7 +105,7 @@ export function OfflineDrawer({ isOnline }: OfflineDrawerProps) {
 }
 
 /* ──────────────────────────────────────────────────────────── */
-/*  DRAWER (tabs → list → detail)                               */
+/*  DRAWER                                                      */
 /* ──────────────────────────────────────────────────────────── */
 type TabKey = "products" | "suppliers" | "clients";
 
@@ -117,7 +113,6 @@ interface EntityDrawerProps {
    open: boolean;
    onClose: () => void;
 }
-
 function EntityDrawer({ open, onClose }: EntityDrawerProps) {
    const [tab, setTab] = useState<TabKey>("products");
    const [view, setView] = useState<"list" | "detail">("list");
@@ -125,47 +120,39 @@ function EntityDrawer({ open, onClose }: EntityDrawerProps) {
       null
    );
 
-   const [products, setProducts] = useState<Product[] | null>(null);
-   const [suppliers, setSuppliers] = useState<Supplier[] | null>(null);
-   const [clients, setClients] = useState<Clients[] | null>(null);
+   const products = useLiveQuery(() => db.products.toArray(), []);
+   const suppliers = useLiveQuery(() => db.suppliers.toArray(), []);
+   const clients = useLiveQuery(() => db.clients.toArray(), []);
 
-   useEffect(() => {
-      const load = async () => {
-         switch (tab) {
-            case "products":
-               if (!products) setProducts(await getAllRecords("products"));
-               break;
-            case "suppliers":
-               if (!suppliers) setSuppliers(await getAllRecords("suppliers"));
-               break;
-            case "clients":
-               if (!clients) setClients(await getAllRecords("clients"));
-               break;
-         }
-      };
-      load().catch(console.error);
-   }, [tab]);
-
-   /* ---------- save helper ---------- */
-   const handleSave = async (updated: any) => {
+   const handleSave = async (updated: any, close = false) => {
       const table =
          tab === "products"
             ? "products"
             : tab === "suppliers"
             ? "suppliers"
             : "clients";
-      const idField = idKey(table);
 
-      await db.table(table).put(updated); 
+      await db.table(table).put(updated);
 
-      // ← pull fresh list from Dexie so React gets new object refs
-      const fresh = await getAllRecords(table as any);
+      if (close) setView("list");
+   };
 
-      if (table === "products") setProducts(fresh as Product[]);
-      if (table === "suppliers") setSuppliers(fresh as Supplier[]);
-      if (table === "clients") setClients(fresh as Clients[]);
+   const handleDelete = async (item: Product | Supplier | Clients) => {
+      const table =
+         tab === "products"
+            ? "products"
+            : tab === "suppliers"
+            ? "suppliers"
+            : "clients";
 
-      setView("list");
+      const id =
+         table === "products"
+            ? (item as Product).productId
+            : table === "suppliers"
+            ? (item as Supplier).supplierId
+            : (item as Clients).clientId;
+
+      await deleteRecord(table as any, id);
    };
 
    return (
@@ -173,6 +160,7 @@ function EntityDrawer({ open, onClose }: EntityDrawerProps) {
          anchor="bottom"
          open={open}
          onClose={onClose}
+         ModalProps={{ keepMounted: true, disableScrollLock: false }}
          PaperProps={{
             sx: {
                height: "90vh",
@@ -191,18 +179,26 @@ function EntityDrawer({ open, onClose }: EntityDrawerProps) {
                variant="fullWidth"
                sx={{ borderBottom: 1, borderColor: "divider", pt: 1 }}
             >
-               <Tab label="Products" value="products" />
-               <Tab label="Suppliers" value="suppliers" />
-               <Tab label="Clients" value="clients" />
+               <Tab label="产品" value="products" />
+               <Tab label="供应商" value="suppliers" />
+               <Tab label="客户" value="clients" />
             </Tabs>
          )}
 
-         <Box sx={{ height: "90vh", overflowY: "auto", p: 1.5 }}>
+         <Box
+            sx={{
+               height: "90vh",
+               overflowY: "auto",
+               p: 1.5,
+               scrollbarWidth: "none",
+               "&::-webkit-scrollbar": { display: "none" },
+            }}
+         >
             {view === "list" && (
                <>
                   {tab === "products" && (
                      <EntityList<Product>
-                        loading={!products}
+                        loading={products === undefined}
                         items={products ?? []}
                         primary={(p) =>
                            p.productChineseName || p.productEnglishName
@@ -217,32 +213,35 @@ function EntityDrawer({ open, onClose }: EntityDrawerProps) {
                            setSelect(p);
                            setView("detail");
                         }}
+                        onDelete={handleDelete}
                      />
                   )}
 
                   {tab === "suppliers" && (
                      <EntityList<Supplier>
-                        loading={!suppliers}
+                        loading={suppliers === undefined}
                         items={suppliers ?? []}
                         primary={(s) => s.supplierName}
-                        secondary={(s) => s.supplierPhoneNumber ?? ""}
+                        secondary={(s) => s.supplierAddress ?? ""}
                         onSelect={(s) => {
                            setSelect(s);
                            setView("detail");
                         }}
+                        onDelete={handleDelete}
                      />
                   )}
 
                   {tab === "clients" && (
                      <EntityList<Clients>
-                        loading={!clients}
+                        loading={clients === undefined}
                         items={clients ?? []}
                         primary={(c) => c.companyName}
-                        secondary={(c) => c.contactEmail ?? ""}
+                        secondary={(c) => c.contactName ?? ""}
                         onSelect={(c) => {
                            setSelect(c);
                            setView("detail");
                         }}
+                        onDelete={handleDelete}
                      />
                   )}
                </>
@@ -271,6 +270,7 @@ interface EntityListProps<T> {
    secondary?: (item: T) => string;
    avatarSrc?: (item: T) => string | undefined;
    onSelect: (item: T) => void;
+   onDelete: (item: T) => void;
 }
 
 function EntityList<T>({
@@ -280,6 +280,7 @@ function EntityList<T>({
    secondary,
    avatarSrc,
    onSelect,
+   onDelete,
 }: EntityListProps<T>) {
    if (loading)
       return (
@@ -295,7 +296,7 @@ function EntityList<T>({
             color="text.secondary"
             sx={{ py: 3, textAlign: "center" }}
          >
-            No data.
+            没有信息。
          </Typography>
       );
 
@@ -311,7 +312,7 @@ function EntityList<T>({
                      "&:hover": { bgcolor: "action.hover" },
                      gap: 1,
                      px: 1,
-                     py: 0.5,
+                     py: 1,
                   }}
                >
                   {avatarSrc && avatarSrc(item) && (
@@ -333,12 +334,24 @@ function EntityList<T>({
                      primary={primary(item)}
                      secondary={secondary ? secondary(item) : undefined}
                      primaryTypographyProps={{
-                        fontSize: "0.85rem",
+                        fontSize: "0.95rem",
                         fontWeight: 600,
                      }}
-                     secondaryTypographyProps={{ fontSize: "0.75rem" }}
+                     secondaryTypographyProps={{ fontSize: "0.85rem" }}
                   />
+
+                  <IconButton
+                     edge="end"
+                     size="small"
+                     onClick={(e) => {
+                        e.stopPropagation();
+                        onDelete(item);
+                     }}
+                  >
+                     <DeleteIcon fontSize="small" />
+                  </IconButton>
                </ListItem>
+
                {idx < items.length - 1 && <Divider component="li" />}
             </Fragment>
          ))}
@@ -347,7 +360,7 @@ function EntityList<T>({
 }
 
 /* ──────────────────────────────────────────────────────────── */
-/*  DETAIL / EDIT FORM                                          */
+/*           EDIT FORM                                          */
 /* ──────────────────────────────────────────────────────────── */
 interface DetailFormProps {
    item: Product | Supplier | Clients;
@@ -357,92 +370,145 @@ interface DetailFormProps {
 }
 
 function DetailForm({ item, tab, onBack, onSave }: DetailFormProps) {
-   // deep copy so we don’t mutate the list item
    const [form, setForm] = useState<Record<string, any>>({ ...item });
-   const [saving, setSaving] = useState(false);
 
-   /* ---------- helpers ---------- */
+   /* ---------------- helpers ---------------- */
    const ensureDataUrl = (b64: string) =>
       b64.startsWith("data:image") ? b64 : `data:image/png;base64,${b64}`;
 
+   const getDeep = (obj: any, path: string) =>
+      path.split(".").reduce((acc, k) => (acc ? acc[k] : undefined), obj);
+
+   const setDeep = (obj: any, path: string, value: any) => {
+      const parts = path.split(".");
+      const last = parts.pop()!;
+      const next = { ...obj };
+      let cur = next;
+      for (const p of parts) {
+         cur[p] = { ...(cur[p] ?? {}) };
+         cur = cur[p];
+      }
+      cur[last] = value;
+      return next;
+   };
+
+   /** update state + persist immediately */
+   const saveNow = (updated: Record<string, any>) => {
+      setForm(updated);
+      onSave(updated);
+   };
+
    const handleChange = (key: string) => (e: ChangeEvent<HTMLInputElement>) =>
-      setForm({ ...form, [key]: e.target.value });
+      saveNow(setDeep(form, key, e.target.value));
 
    const handleFile: React.ChangeEventHandler<HTMLInputElement> = async (e) => {
       const file = e.target.files?.[0];
       if (!file) return;
+
       const blobUrl = URL.createObjectURL(file);
       const b64 = await getBase64FromBlobUrl(blobUrl);
-      const base64 = b64 ? ensureDataUrl(b64) : "";
+      URL.revokeObjectURL(blobUrl);
 
-      setTimeout(() => URL.revokeObjectURL(blobUrl), 1000);
-      setForm({ ...form, productImage: base64 });
+      saveNow({ ...form, image: ensureDataUrl(b64 ?? "") });
    };
 
-   /* ---------- meta per entity ---------- */
+   const adornmentsFor = (key: string) => {
+      if (key === "unitPrice") {
+         return {
+            startAdornment: <InputAdornment position="start">¥</InputAdornment>,
+         };
+      }
+
+      if (key === "packingMass.packingMassQuantity") {
+         const unit = getDeep(form, "packingMass.packingMassUnit") ?? "kg";
+         return {
+            endAdornment: (
+               <InputAdornment position="end">{unit}</InputAdornment>
+            ),
+         };
+      }
+
+      return undefined;
+   };
+
+   /* ---------------- meta per entity ---------------- */
    const FIELDS: Record<
       TabKey,
       { key: string; label: string; type?: string }[]
    > = {
       products: [
-         { key: "productChineseName", label: "Chinese Name" },
-         { key: "productEnglishName", label: "English Name" },
-         { key: "unitPrice", label: "Unit Price", type: "number" },
-         { key: "currency", label: "Currency" },
-         { key: "material", label: "Material" },
-         { key: "hsCode", label: "HS Code" },
-         { key: "packing", label: "Packing" },
-         { key: "productImage", label: "Image", type: "file" },
+         { key: "productChineseName", label: "产品中文名" },
+         { key: "productEnglishName", label: "产品英文名" },
+         { key: "unitPrice", label: "单位价格", type: "number" },
+         { key: "hsCode", label: "HS编码" },
+         { key: "material", label: "材料" },
+         { key: "packing", label: "包装", type: "number" },
+
+         { key: "packingVolume.length", label: "长", type: "number" },
+         { key: "packingVolume.width", label: "宽", type: "number" },
+         { key: "packingVolume.height", label: "高", type: "number" },
+         {
+            key: "packingMass.packingMassQuantity",
+            label: "包装重量",
+            type: "number",
+         },
       ],
       suppliers: [
-         { key: "supplierName", label: "Name" },
-         { key: "supplierPhoneNumber", label: "Phone" },
-         { key: "supplierAddress", label: "Address" },
-         { key: "supplierEmail", label: "Email" },
+         { key: "supplierName", label: "供应商名称" },
+         { key: "supplierPhoneNumber", label: "电话", type: "number" },
+         { key: "supplierAddress", label: "地址" },
+         { key: "supplierEmail", label: "邮箱" },
       ],
       clients: [
-         { key: "companyName", label: "Company" },
-         { key: "contactName", label: "Contact" },
-         { key: "contactPhoneNumber", label: "Phone" },
-         { key: "contactEmail", label: "Email" },
-         { key: "eoriNumber", label: "EORI" },
+         { key: "companyName", label: "公司全称" },
+         { key: "address", label: "完整地址" },
+         { key: "contactName", label: "联系人" },
+         { key: "contactPhoneNumber", label: "电话号码", type: "number" },
+         { key: "contactEmail", label: "电子邮件地址" },
+         { key: "eoriNumber", label: "EORI 编号" },
+         { key: "vatNumber", label: "VAT 增值税号" },
       ],
    };
 
-   /* ---------- save ---------- */
-   const submit = async () => {
-      setSaving(true);
-      await onSave(form); // parent will `.put()` entire record
-      setSaving(false);
-   };
+   const dimensionKeys = [
+      "packingVolume.length",
+      "packingVolume.width",
+      "packingVolume.height",
+   ];
 
-   /* ---------- UI ---------- */
    return (
-      <Box sx={{ display: "flex", flexDirection: "column", gap: 1.25 }}>
-         {/* Preview first so you can’t miss it */}
-         {form.productImage && (
-            <Box
-               component="img"
-               src={ensureDataUrl(form.productImage)}
-               alt="preview"
-               sx={{ width: "100%", borderRadius: 1, mb: 1 }}
-            />
-         )}
-
-         <IconButton onClick={onBack} size="small">
-            <ArrowLeft size={20} />
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
+         <IconButton
+            onClick={onBack}
+            size="small"
+            sx={{
+               position: "fixed",
+               height: 35,
+               width: 35,
+               m: 1.5,
+               zIndex: 1000,
+            }}
+         >
+            <ArrowLeft />
          </IconButton>
 
-         {FIELDS[tab].map(({ key, label, type }) =>
-            type === "file" ? (
+         {form.image && (
+            <Box sx={{ position: "relative", width: "100%", mb: 1 }}>
+               <Box
+                  component="img"
+                  src={ensureDataUrl(form.image)}
+                  alt="preview"
+                  sx={{ width: "100%", borderRadius: 3 }}
+               />
+
                <Button
-                  key={key}
-                  variant="outlined"
-                  component="label"
+                  variant="contained"
                   size="small"
-                  sx={{ alignSelf: "flex-start" }}
+                  component="label"
+                  color="info"
+                  sx={{ position: "absolute", bottom: 12, right: 8 }}
                >
-                  {form.productImage ? "Replace image" : "Upload image"}
+                  更换图片
                   <input
                      type="file"
                      accept="image/*"
@@ -450,38 +516,60 @@ function DetailForm({ item, tab, onBack, onSave }: DetailFormProps) {
                      onChange={handleFile}
                   />
                </Button>
-            ) : (
-               <TextField
-                  key={key}
-                  label={label}
-                  type={type ?? "text"}
-                  value={form[key] ?? ""}
-                  onChange={handleChange(key)}
-                  fullWidth
-                  size="small"
-               />
-            )
+            </Box>
          )}
 
-         <Button
-            variant="contained"
-            size="small"
-            onClick={submit}
-            disabled={saving}
-            sx={{ alignSelf: "flex-end" }}
-         >
-            {saving ? "Saving…" : "Save"}
-         </Button>
+         <Box mt={tab !== "products" ? 8 : 2}>
+            {FIELDS[tab]
+               .filter(({ key }) => !dimensionKeys.includes(key))
+               .map(({ key, label, type }) => (
+                  <TextField
+                     key={key}
+                     label={label}
+                     type={type ?? "text"}
+                     value={getDeep(form, key) ?? ""}
+                     onChange={handleChange(key)}
+                     fullWidth
+                     margin="normal"
+                     size="small"
+                     InputProps={adornmentsFor(key)}
+                  />
+               ))}
+
+            <Stack
+               direction={"row"}
+               sx={{
+                  display: "flex",
+                  alignContent: "center",
+                  alignItems: "center",
+               }}
+               gap={1.5}
+            >
+               {tab === "products" && (
+                  <Grid container spacing={1} sx={{ mt: 1 }}>
+                     {[
+                        { key: "packingVolume.length", label: "长" },
+                        { key: "packingVolume.width", label: "宽" },
+                        { key: "packingVolume.height", label: "高" },
+                     ].map(({ key, label }) => (
+                        <Grid item xs={4} key={key}>
+                           <TextField
+                              label={label}
+                              type="number"
+                              value={getDeep(form, key) ?? ""}
+                              onChange={handleChange(key)}
+                              fullWidth
+                              size="small"
+                           />
+                        </Grid>
+                     ))}
+                  </Grid>
+               )}
+               <p>{getDeep(form, "packingVolume.packingUnit")}</p>
+            </Stack>
+         </Box>
       </Box>
    );
-}
-/* ──────────────────────────────────────────────────────────── */
-function idKey(table: string) {
-   return table === "products"
-      ? "productId"
-      : table === "suppliers"
-      ? "supplierId"
-      : "clientId";
 }
 
 function ensureDataUrl(str?: string) {

--- a/src/components/dashboard/core/offlineDrawer.tsx
+++ b/src/components/dashboard/core/offlineDrawer.tsx
@@ -1,0 +1,490 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+/* ──────────────────────────────────────────────────────────── */
+/*  Offline‑indicator FAB  +  80 vh bottom drawer (Dexie)       */
+/*  Full‑field editor, image upload (base‑64), slim UI          */
+/* ──────────────────────────────────────────────────────────── */
+import {
+   useState,
+   useEffect,
+   Fragment,
+   SyntheticEvent,
+   ChangeEvent,
+} from "react";
+import {
+   Box,
+   Collapse,
+   Grow,
+   Typography,
+   Drawer,
+   Tabs,
+   Tab,
+   List,
+   ListItem,
+   ListItemText,
+   Divider,
+   CircularProgress,
+   TextField,
+   Button,
+   IconButton,
+   Avatar,
+} from "@mui/material";
+import { CloudSlash, Package, ArrowLeft } from "phosphor-react";
+import {
+   getProductCount,
+   getAllRecords,
+   updateRecord,
+   db,
+} from "../../../lib/dexieUtils";
+import getBase64FromBlobUrl from "../../../lib/blob-to-blob64";
+import { Product, Supplier, Clients } from "../../../types/types";
+
+/* ──────────────────────────────────────────────────────────── */
+/*  MAIN FLOATING BUTTON + DRAWER                               */
+/* ──────────────────────────────────────────────────────────── */
+interface OfflineDrawerProps {
+   isOnline: boolean;
+}
+
+export function OfflineDrawer({ isOnline }: OfflineDrawerProps) {
+   const [count, setCount] = useState<number | null>(null);
+   const [showCloud, setShowCloud] = useState(true);
+   const [open, setOpen] = useState(false);
+
+   useEffect(() => {
+      getProductCount().then(setCount).catch(console.error);
+   }, []);
+
+   useEffect(() => {
+      if (!isOnline) {
+         const t = setTimeout(() => setShowCloud(false), 1200);
+         return () => clearTimeout(t);
+      }
+      setShowCloud(true);
+   }, [isOnline]);
+
+   if (isOnline) return null;
+
+   return (
+      <>
+         {/* FAB */}
+         <Grow in>
+            <Box
+               onClick={() => setOpen(true)}
+               sx={{
+                  position: "fixed",
+                  bottom: 16,
+                  right: 16,
+                  display: "flex",
+                  alignItems: "center",
+                  px: 1.25,
+                  py: 0.75,
+                  borderRadius: 999,
+                  boxShadow: 4,
+                  bgcolor: (t) => t.palette.background.default,
+                  cursor: "pointer",
+                  zIndex: 1300,
+               }}
+            >
+               <Collapse in={showCloud} orientation="horizontal" timeout={400}>
+                  <CloudSlash size={20} weight="fill" />
+               </Collapse>
+
+               <Collapse in={!showCloud} orientation="horizontal" timeout={400}>
+                  <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+                     <Package size={18} weight="fill" />
+                     <Typography
+                        variant="caption"
+                        sx={{ fontWeight: 700, fontSize: "0.75rem" }}
+                     >
+                        {count ?? "…"}
+                     </Typography>
+                  </Box>
+               </Collapse>
+            </Box>
+         </Grow>
+
+         <EntityDrawer open={open} onClose={() => setOpen(false)} />
+      </>
+   );
+}
+
+/* ──────────────────────────────────────────────────────────── */
+/*  DRAWER (tabs → list → detail)                               */
+/* ──────────────────────────────────────────────────────────── */
+type TabKey = "products" | "suppliers" | "clients";
+
+interface EntityDrawerProps {
+   open: boolean;
+   onClose: () => void;
+}
+
+function EntityDrawer({ open, onClose }: EntityDrawerProps) {
+   const [tab, setTab] = useState<TabKey>("products");
+   const [view, setView] = useState<"list" | "detail">("list");
+   const [select, setSelect] = useState<Product | Supplier | Clients | null>(
+      null
+   );
+
+   const [products, setProducts] = useState<Product[] | null>(null);
+   const [suppliers, setSuppliers] = useState<Supplier[] | null>(null);
+   const [clients, setClients] = useState<Clients[] | null>(null);
+
+   useEffect(() => {
+      const load = async () => {
+         switch (tab) {
+            case "products":
+               if (!products) setProducts(await getAllRecords("products"));
+               break;
+            case "suppliers":
+               if (!suppliers) setSuppliers(await getAllRecords("suppliers"));
+               break;
+            case "clients":
+               if (!clients) setClients(await getAllRecords("clients"));
+               break;
+         }
+      };
+      load().catch(console.error);
+   }, [tab]);
+
+   /* ---------- save helper ---------- */
+   const handleSave = async (updated: any) => {
+      const table =
+         tab === "products"
+            ? "products"
+            : tab === "suppliers"
+            ? "suppliers"
+            : "clients";
+      const idField = idKey(table);
+
+      await db.table(table).put(updated); 
+
+      // ← pull fresh list from Dexie so React gets new object refs
+      const fresh = await getAllRecords(table as any);
+
+      if (table === "products") setProducts(fresh as Product[]);
+      if (table === "suppliers") setSuppliers(fresh as Supplier[]);
+      if (table === "clients") setClients(fresh as Clients[]);
+
+      setView("list");
+   };
+
+   return (
+      <Drawer
+         anchor="bottom"
+         open={open}
+         onClose={onClose}
+         PaperProps={{
+            sx: {
+               height: "90vh",
+               borderTopLeftRadius: 16,
+               borderTopRightRadius: 16,
+            },
+         }}
+      >
+         {view === "list" && (
+            <Tabs
+               value={tab}
+               onChange={(_e: SyntheticEvent, v: TabKey) => {
+                  setTab(v);
+                  setView("list");
+               }}
+               variant="fullWidth"
+               sx={{ borderBottom: 1, borderColor: "divider", pt: 1 }}
+            >
+               <Tab label="Products" value="products" />
+               <Tab label="Suppliers" value="suppliers" />
+               <Tab label="Clients" value="clients" />
+            </Tabs>
+         )}
+
+         <Box sx={{ height: "90vh", overflowY: "auto", p: 1.5 }}>
+            {view === "list" && (
+               <>
+                  {tab === "products" && (
+                     <EntityList<Product>
+                        loading={!products}
+                        items={products ?? []}
+                        primary={(p) =>
+                           p.productChineseName || p.productEnglishName
+                        }
+                        secondary={(p) =>
+                           `${p.currency ?? ""}${p.unitPrice ?? ""}  •  ${
+                              p.material ?? ""
+                           }`
+                        }
+                        avatarSrc={(p) => p.image}
+                        onSelect={(p) => {
+                           setSelect(p);
+                           setView("detail");
+                        }}
+                     />
+                  )}
+
+                  {tab === "suppliers" && (
+                     <EntityList<Supplier>
+                        loading={!suppliers}
+                        items={suppliers ?? []}
+                        primary={(s) => s.supplierName}
+                        secondary={(s) => s.supplierPhoneNumber ?? ""}
+                        onSelect={(s) => {
+                           setSelect(s);
+                           setView("detail");
+                        }}
+                     />
+                  )}
+
+                  {tab === "clients" && (
+                     <EntityList<Clients>
+                        loading={!clients}
+                        items={clients ?? []}
+                        primary={(c) => c.companyName}
+                        secondary={(c) => c.contactEmail ?? ""}
+                        onSelect={(c) => {
+                           setSelect(c);
+                           setView("detail");
+                        }}
+                     />
+                  )}
+               </>
+            )}
+
+            {view === "detail" && select && (
+               <DetailForm
+                  item={select}
+                  tab={tab}
+                  onBack={() => setView("list")}
+                  onSave={handleSave}
+               />
+            )}
+         </Box>
+      </Drawer>
+   );
+}
+
+/* ──────────────────────────────────────────────────────────── */
+/*  SHARED LIST COMPONENT                                       */
+/* ──────────────────────────────────────────────────────────── */
+interface EntityListProps<T> {
+   loading: boolean;
+   items: T[];
+   primary: (item: T) => string;
+   secondary?: (item: T) => string;
+   avatarSrc?: (item: T) => string | undefined;
+   onSelect: (item: T) => void;
+}
+
+function EntityList<T>({
+   loading,
+   items,
+   primary,
+   secondary,
+   avatarSrc,
+   onSelect,
+}: EntityListProps<T>) {
+   if (loading)
+      return (
+         <Box sx={{ py: 3, textAlign: "center" }}>
+            <CircularProgress size={24} />
+         </Box>
+      );
+
+   if (!items.length)
+      return (
+         <Typography
+            variant="body2"
+            color="text.secondary"
+            sx={{ py: 3, textAlign: "center" }}
+         >
+            No data.
+         </Typography>
+      );
+
+   return (
+      <List disablePadding>
+         {items.map((item: any, idx) => (
+            <Fragment key={idx}>
+               <ListItem
+                  button
+                  onClick={() => onSelect(item)}
+                  sx={{
+                     borderRadius: 2,
+                     "&:hover": { bgcolor: "action.hover" },
+                     gap: 1,
+                     px: 1,
+                     py: 0.5,
+                  }}
+               >
+                  {avatarSrc && avatarSrc(item) && (
+                     <Box
+                        component="img"
+                        src={ensureDataUrl(avatarSrc(item))}
+                        alt="thumb"
+                        sx={{
+                           width: 64,
+                           height: 64,
+                           objectFit: "cover",
+                           borderRadius: 1,
+                           flexShrink: 0,
+                        }}
+                     />
+                  )}
+
+                  <ListItemText
+                     primary={primary(item)}
+                     secondary={secondary ? secondary(item) : undefined}
+                     primaryTypographyProps={{
+                        fontSize: "0.85rem",
+                        fontWeight: 600,
+                     }}
+                     secondaryTypographyProps={{ fontSize: "0.75rem" }}
+                  />
+               </ListItem>
+               {idx < items.length - 1 && <Divider component="li" />}
+            </Fragment>
+         ))}
+      </List>
+   );
+}
+
+/* ──────────────────────────────────────────────────────────── */
+/*  DETAIL / EDIT FORM                                          */
+/* ──────────────────────────────────────────────────────────── */
+interface DetailFormProps {
+   item: Product | Supplier | Clients;
+   tab: TabKey;
+   onBack: () => void;
+   onSave: (updated: any) => void;
+}
+
+function DetailForm({ item, tab, onBack, onSave }: DetailFormProps) {
+   // deep copy so we don’t mutate the list item
+   const [form, setForm] = useState<Record<string, any>>({ ...item });
+   const [saving, setSaving] = useState(false);
+
+   /* ---------- helpers ---------- */
+   const ensureDataUrl = (b64: string) =>
+      b64.startsWith("data:image") ? b64 : `data:image/png;base64,${b64}`;
+
+   const handleChange = (key: string) => (e: ChangeEvent<HTMLInputElement>) =>
+      setForm({ ...form, [key]: e.target.value });
+
+   const handleFile: React.ChangeEventHandler<HTMLInputElement> = async (e) => {
+      const file = e.target.files?.[0];
+      if (!file) return;
+      const blobUrl = URL.createObjectURL(file);
+      const b64 = await getBase64FromBlobUrl(blobUrl);
+      const base64 = b64 ? ensureDataUrl(b64) : "";
+
+      setTimeout(() => URL.revokeObjectURL(blobUrl), 1000);
+      setForm({ ...form, productImage: base64 });
+   };
+
+   /* ---------- meta per entity ---------- */
+   const FIELDS: Record<
+      TabKey,
+      { key: string; label: string; type?: string }[]
+   > = {
+      products: [
+         { key: "productChineseName", label: "Chinese Name" },
+         { key: "productEnglishName", label: "English Name" },
+         { key: "unitPrice", label: "Unit Price", type: "number" },
+         { key: "currency", label: "Currency" },
+         { key: "material", label: "Material" },
+         { key: "hsCode", label: "HS Code" },
+         { key: "packing", label: "Packing" },
+         { key: "productImage", label: "Image", type: "file" },
+      ],
+      suppliers: [
+         { key: "supplierName", label: "Name" },
+         { key: "supplierPhoneNumber", label: "Phone" },
+         { key: "supplierAddress", label: "Address" },
+         { key: "supplierEmail", label: "Email" },
+      ],
+      clients: [
+         { key: "companyName", label: "Company" },
+         { key: "contactName", label: "Contact" },
+         { key: "contactPhoneNumber", label: "Phone" },
+         { key: "contactEmail", label: "Email" },
+         { key: "eoriNumber", label: "EORI" },
+      ],
+   };
+
+   /* ---------- save ---------- */
+   const submit = async () => {
+      setSaving(true);
+      await onSave(form); // parent will `.put()` entire record
+      setSaving(false);
+   };
+
+   /* ---------- UI ---------- */
+   return (
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 1.25 }}>
+         {/* Preview first so you can’t miss it */}
+         {form.productImage && (
+            <Box
+               component="img"
+               src={ensureDataUrl(form.productImage)}
+               alt="preview"
+               sx={{ width: "100%", borderRadius: 1, mb: 1 }}
+            />
+         )}
+
+         <IconButton onClick={onBack} size="small">
+            <ArrowLeft size={20} />
+         </IconButton>
+
+         {FIELDS[tab].map(({ key, label, type }) =>
+            type === "file" ? (
+               <Button
+                  key={key}
+                  variant="outlined"
+                  component="label"
+                  size="small"
+                  sx={{ alignSelf: "flex-start" }}
+               >
+                  {form.productImage ? "Replace image" : "Upload image"}
+                  <input
+                     type="file"
+                     accept="image/*"
+                     hidden
+                     onChange={handleFile}
+                  />
+               </Button>
+            ) : (
+               <TextField
+                  key={key}
+                  label={label}
+                  type={type ?? "text"}
+                  value={form[key] ?? ""}
+                  onChange={handleChange(key)}
+                  fullWidth
+                  size="small"
+               />
+            )
+         )}
+
+         <Button
+            variant="contained"
+            size="small"
+            onClick={submit}
+            disabled={saving}
+            sx={{ alignSelf: "flex-end" }}
+         >
+            {saving ? "Saving…" : "Save"}
+         </Button>
+      </Box>
+   );
+}
+/* ──────────────────────────────────────────────────────────── */
+function idKey(table: string) {
+   return table === "products"
+      ? "productId"
+      : table === "suppliers"
+      ? "supplierId"
+      : "clientId";
+}
+
+function ensureDataUrl(str?: string) {
+   if (!str) return "";
+   return str.startsWith("data:image") ? str : `data:image/png;base64,${str}`;
+}

--- a/src/components/dashboard/supplier/addNewSupplierModal.tsx
+++ b/src/components/dashboard/supplier/addNewSupplierModal.tsx
@@ -17,15 +17,17 @@ import { useTheme } from "@mui/material/styles";
 import { X } from "phosphor-react";
 import ProductandCompanyData from "../../../data/products_companies.json";
 import { useProductSupplierClientContext } from "../../../contexts/productSupplierClientContextProvider";
+import { addRecord } from "../../../lib/dexieUtils";
 
 interface Props {
    open: boolean;
    onClose: () => void;
+   isOnline: boolean;
 }
 
-const NewSupplierModal: React.FC<Props> = ({ open, onClose }) => {
+const NewSupplierModal: React.FC<Props> = ({ open, onClose, isOnline }) => {
    const theme = useTheme();
-   const { addSupplier } = useProductSupplierClientContext();
+   const { addSupplier, setErrorMessages } = useProductSupplierClientContext();
 
    const [supplierName, setSupplierName] = useState<string>("");
    const [selectedSupplier, setSelectedSupplier] = useState<string | null>(
@@ -63,6 +65,20 @@ const NewSupplierModal: React.FC<Props> = ({ open, onClose }) => {
 
    const handleSave = () => {
       if (!canSave) return;
+
+      if (!isOnline) {
+         addRecord("suppliers", {
+            supplierName,
+            supplierAddress,
+            supplierEmail,
+            supplierPhoneNumber: supplierPhone,
+         });
+
+         setErrorMessages(`添加${supplierName}成功`)
+         handleReset();
+         onClose();
+         return;
+      }
 
       addSupplier({
          supplierName,

--- a/src/components/dashboard/supplier/addNewSupplierModal.tsx
+++ b/src/components/dashboard/supplier/addNewSupplierModal.tsx
@@ -71,7 +71,7 @@ const NewSupplierModal: React.FC<Props> = ({ open, onClose, isOnline }) => {
             supplierName,
             supplierAddress,
             supplierEmail,
-            supplierPhoneNumber: supplierPhone,
+            supplierPhone,
          });
 
          setErrorMessages(`添加${supplierName}成功`)
@@ -96,6 +96,7 @@ const NewSupplierModal: React.FC<Props> = ({ open, onClose, isOnline }) => {
       setSelectedSupplier(null);
       setSupplierAddress("");
       setSupplierPhone("");
+      setSupplierEmail("");
    };
 
    return (

--- a/src/contexts/productSupplierClientContextProvider.tsx
+++ b/src/contexts/productSupplierClientContextProvider.tsx
@@ -4,13 +4,16 @@ import React, {
    useState,
    ReactNode,
    useEffect,
+   useMemo,
 } from "react";
 import { Product, Supplier, Clients } from "../types/types";
 import { getFunctions, httpsCallable } from "firebase/functions";
 import { getDocs, collection, onSnapshot } from "firebase/firestore";
 import { db } from "../configs/firebase";
+import { db as DexieDataBase } from "../lib/dexieUtils";
 import { useAuth } from "./authContexts";
 import { useNavigate } from "react-router";
+import { useLiveQuery } from "dexie-react-hooks";
 
 export type ProductSupplierClientContextType = {
    addProduct: (product: any) => Promise<void>;
@@ -75,10 +78,57 @@ export const ProductSupplierClientContextProvider = ({
    const [deletedClient, setDeletedClient] = useState(false);
 
    const [products, setProducts] = useState<{ [key: string]: Product }>({});
+
    const [clients, setClients] = useState<{ [key: string]: Clients }>({});
+   const [firestoreClients, setFirestoreClients] = useState<{ [key: string]: Clients }>({});
+
    const [suppliers, setSuppliers] = useState<{ [key: string]: Supplier }>({});
+   const [firestoreSuppliers, setFirestoreSuppliers] = useState<{
+      [key: string]: Supplier;
+   }>({});
+
    const functions = getFunctions();
    const navigate = useNavigate();
+
+   const dexieClients = useLiveQuery(() => DexieDataBase.clients.toArray(), []);
+   const dexieSuppliers = useLiveQuery(
+      () => DexieDataBase.suppliers.toArray(),
+      []
+   );
+
+   // listen to dexie changes and merge with firestore clients
+   useEffect(() => {
+      if (!dexieClients) {
+         return;
+      }
+
+      const merged = { ...firestoreClients };
+
+      dexieClients.forEach((client) => {
+         if (!merged[client.clientId]) {
+            merged[client.clientId] = client;
+         }
+      });
+
+      setClients(merged);
+
+   }, [dexieClients, firestoreClients]); 
+   
+   useEffect(() => {
+      if (!dexieSuppliers) {
+         return;
+      }
+
+      const merged = { ...firestoreSuppliers };
+
+      dexieSuppliers.forEach((supplier) => {
+         if (!merged[supplier.supplierId]) {
+            merged[supplier.supplierId] = supplier;
+         }
+      });
+
+      setSuppliers(merged);
+   }, [dexieSuppliers, firestoreSuppliers]);  
 
    // listen to firestore product change
    useEffect(() => {
@@ -152,7 +202,7 @@ export const ProductSupplierClientContextProvider = ({
                map[c.clientId] = c; // keyed by clientId
             });
 
-            setClients(map);
+            setFirestoreClients(map);
          },
          (err) => {
             console.error("Firestore listener error (clients):", err);
@@ -192,7 +242,7 @@ export const ProductSupplierClientContextProvider = ({
                map[c.supplierId] = c;
             });
 
-            setSuppliers(map);
+            setFirestoreSuppliers(map);
          },
          (err) => {
             console.error("Firestore listener error (suppliers):", err);

--- a/src/contexts/productSupplierClientContextProvider.tsx
+++ b/src/contexts/productSupplierClientContextProvider.tsx
@@ -26,6 +26,8 @@ export type ProductSupplierClientContextType = {
    getSuppliers: () => Promise<Object>;
    toggleSaveUnsaveProduct: (productId: string) => Promise<void>;
    setAddedProduct: React.Dispatch<React.SetStateAction<boolean>>;
+   setAddedClient: React.Dispatch<React.SetStateAction<boolean>>;
+   setAddedSupplier: React.Dispatch<React.SetStateAction<boolean>>;
    addedProduct: boolean;
    editedProduct: boolean;
    deletedProduct: boolean;
@@ -401,6 +403,8 @@ export const ProductSupplierClientContextProvider = ({
             toggleSaveUnsaveProduct,
             addedProduct,
             setAddedProduct,
+            setAddedClient,
+            setAddedSupplier,
             editedProduct,
             deletedProduct,
             addedSupplier,

--- a/src/contexts/productSupplierClientContextProvider.tsx
+++ b/src/contexts/productSupplierClientContextProvider.tsx
@@ -6,7 +6,7 @@ import React, {
    useEffect,
    useMemo,
 } from "react";
-import { Product, Supplier, Clients } from "../types/types";
+import { Product, Supplier, Clients, SyncPayload } from "../types/types";
 import { getFunctions, httpsCallable } from "firebase/functions";
 import { getDocs, collection, onSnapshot } from "firebase/firestore";
 import { db } from "../configs/firebase";
@@ -46,6 +46,8 @@ export type ProductSupplierClientContextType = {
    clients: { [key: string]: any };
    errorMessages: string;
    setErrorMessages: React.Dispatch<React.SetStateAction<string>>;
+   syncAll: (payload: SyncPayload) => Promise<void>;
+   syncState: "idle" | "syncing" | "done";
 };
 
 const ProductSupplierClientContext = createContext<
@@ -76,11 +78,16 @@ export const ProductSupplierClientContextProvider = ({
    const [addedClient, setAddedClient] = useState(false);
    const [editedClient, setEditedClient] = useState(false);
    const [deletedClient, setDeletedClient] = useState(false);
+   const [syncState, setSyncState] = useState<"idle" | "syncing" | "done">(
+      "idle"
+   );
 
    const [products, setProducts] = useState<{ [key: string]: Product }>({});
 
    const [clients, setClients] = useState<{ [key: string]: Clients }>({});
-   const [firestoreClients, setFirestoreClients] = useState<{ [key: string]: Clients }>({});
+   const [firestoreClients, setFirestoreClients] = useState<{
+      [key: string]: Clients;
+   }>({});
 
    const [suppliers, setSuppliers] = useState<{ [key: string]: Supplier }>({});
    const [firestoreSuppliers, setFirestoreSuppliers] = useState<{
@@ -111,9 +118,8 @@ export const ProductSupplierClientContextProvider = ({
       });
 
       setClients(merged);
+   }, [dexieClients, firestoreClients]);
 
-   }, [dexieClients, firestoreClients]); 
-   
    useEffect(() => {
       if (!dexieSuppliers) {
          return;
@@ -128,7 +134,7 @@ export const ProductSupplierClientContextProvider = ({
       });
 
       setSuppliers(merged);
-   }, [dexieSuppliers, firestoreSuppliers]);  
+   }, [dexieSuppliers, firestoreSuppliers]);
 
    // listen to firestore product change
    useEffect(() => {
@@ -436,6 +442,40 @@ export const ProductSupplierClientContextProvider = ({
       }
    }
 
+   async function syncAll(payload: SyncPayload) {
+      try {
+         setSyncState("syncing");
+
+         const syncAllFn = httpsCallable<SyncPayload, { success: boolean }>(
+            getFunctions(),
+            "syncAll"
+         );
+
+         const { data } = await syncAllFn(payload);
+
+         if (data?.success) {
+            await Promise.all([
+               DexieDataBase.products.clear(),
+               DexieDataBase.suppliers.clear(),
+               DexieDataBase.clients.clear(),
+            ]);
+
+            setSyncState("done");
+            setErrorMessages("同步成功")
+         } else {
+            setErrorMessages("信息可能破坏了。");
+            setSyncState("idle");
+            throw new Error("Cloud function returned failure");
+         }
+      } catch (err: any) {
+         console.error("SyncAll failed:", err);
+         setErrorMessages(
+            err.message || "同步失败，请稍后重试；信息可能破坏了。"
+         );
+         setSyncState("idle");
+      }
+   }
+
    return (
       <ProductSupplierClientContext.Provider
          value={{
@@ -469,6 +509,8 @@ export const ProductSupplierClientContextProvider = ({
             clients,
             errorMessages,
             setErrorMessages,
+            syncAll,
+            syncState,
          }}
       >
          {children}

--- a/src/lib/InteralProductsPDFBuilder.tsx
+++ b/src/lib/InteralProductsPDFBuilder.tsx
@@ -208,7 +208,7 @@ export async function BuildInternalProductPDF({
             p.clients.map((id) => clients[id].companyName).join(", ") ?? "",
          ],
          ["Supplier:", suppliers[p.supplierId]?.supplierName ?? ""],
-         ["Phone", suppliers[p.supplierId]?.supplierPhoneNumber ?? ""],
+         ["Phone", suppliers[p.supplierId]?.supplierPhone ?? ""],
          ["Email", suppliers[p.supplierId]?.supplierEmail ?? ""],
          ["Address:", suppliers[p.supplierId]?.supplierAddress ?? ""],
          ["Additional Notes:", p.additionalNotes ?? ""],

--- a/src/lib/blob-to-blob64.tsx
+++ b/src/lib/blob-to-blob64.tsx
@@ -5,7 +5,7 @@ export default async function getBase64FromBlobUrl(
       const res = await fetch(blobUrl);
       if (!res.ok) throw new Error(`Fetch failed: ${res.status}`);
 
-      const contentType = res.headers.get("Content-Type") || "image/png";
+      const contentType = res.headers.get("Content-Type") || "image/jpeg";
       const buf = await res.arrayBuffer();
 
       let binary = "";

--- a/src/lib/blob-to-blob64.tsx
+++ b/src/lib/blob-to-blob64.tsx
@@ -1,8 +1,11 @@
-export default async function getBase64FromBlobUrl(blobUrl: string) {
+export default async function getBase64FromBlobUrl(
+   blobUrl: string
+): Promise<string | undefined> {
    try {
       const res = await fetch(blobUrl);
       if (!res.ok) throw new Error(`Fetch failed: ${res.status}`);
 
+      const contentType = res.headers.get("Content-Type") || "image/png";
       const buf = await res.arrayBuffer();
 
       let binary = "";
@@ -13,8 +16,9 @@ export default async function getBase64FromBlobUrl(blobUrl: string) {
          binary += String.fromCharCode(...bytes.subarray(i, i + chunkSize));
       }
 
-      return btoa(binary);
+      const base64 = btoa(binary);
+      return `data:${contentType};base64,${base64}`;
    } catch (err: any) {
-      console.error("Error in blob -> base 64 conversion: " + err);
+      console.error("Error in blob conversion to base64:", err);
    }
 }

--- a/src/lib/dexieUtils.tsx
+++ b/src/lib/dexieUtils.tsx
@@ -1,0 +1,152 @@
+import Dexie, { Table } from "dexie";
+import { v4 as uuidv4 } from "uuid";
+import { Product, Supplier, Clients } from "../types/types";
+
+// Initialize Dexie database
+class FulcrumsDatabase extends Dexie {
+   products!: Table<Product, string>;
+   suppliers!: Table<Supplier, string>;
+   clients!: Table<Clients, string>;
+
+   constructor() {
+      super("FulcrumsDatabase");
+      this.version(1).stores({
+         products:
+            "productId,productChineseName,productEnglishName,unitPrice,material,hsCode,packing,saved,updatedAt,supplierId,currency",
+         suppliers:
+            "supplierId,supplierName,supplierPhoneNumber,supplierAddress,supplierEmail",
+         clients:
+            "clientId,companyName,contactEmail,contactName,contactPhoneNumber,eoriNumber,updatedAt",
+      });
+   }
+}
+
+const db = new FulcrumsDatabase();
+
+// Map table names to their corresponding entity types
+type TableEntityMap = {
+   products: Product;
+   suppliers: Supplier;
+   clients: Clients;
+};
+
+// Generic type for table names
+type TableName = keyof TableEntityMap;
+
+// Utility to ensure ID is provided or generated
+function ensureId<T extends TableEntityMap[TableName]>(
+   tableName: TableName,
+   record: Partial<T>
+): T {
+   const idField =
+      tableName === "products"
+         ? "productId"
+         : tableName === "suppliers"
+         ? "supplierId"
+         : "clientId";
+   return {
+      ...record,
+      [idField]: (record as any)[idField] || uuidv4(),
+   } as T;
+}
+
+// Generic CRUD functions
+export async function addRecord<T extends TableEntityMap[TableName]>(
+   tableName: TableName,
+   record: Partial<T>
+): Promise<string> {
+   try {
+      const recordWithId = ensureId(tableName, record);
+      return await db.table(tableName).add(recordWithId);
+      
+   } catch (error) {
+      console.error(`Error adding record to ${tableName}:`, error);
+      throw new Error(`Failed to add record to ${tableName}`);
+   }
+}
+
+export async function addRecords<T extends TableEntityMap[TableName]>(
+   tableName: TableName,
+   records: Partial<T>[]
+): Promise<void> {
+   try {
+      const recordsWithIds = records.map((record) =>
+         ensureId(tableName, record)
+      );
+      await db.table(tableName).bulkAdd(recordsWithIds);
+   } catch (error) {
+      console.error(`Error adding records to ${tableName}:`, error);
+      throw new Error(`Failed to add records to ${tableName}`);
+   }
+}
+
+export async function getAllRecords<T extends TableEntityMap[TableName]>(
+   tableName: TableName
+): Promise<T[]> {
+   try {
+      return await db.table(tableName).toArray();
+   } catch (error) {
+      console.error(`Error retrieving records from ${tableName}:`, error);
+      throw new Error(`Failed to retrieve records from ${tableName}`);
+   }
+}
+
+export async function getRecordById<T extends TableEntityMap[TableName]>(
+   tableName: TableName,
+   id: string
+): Promise<T | undefined> {
+   try {
+      return await db.table(tableName).get(id);
+   } catch (error) {
+      console.error(`Error retrieving record ${id} from ${tableName}:`, error);
+      throw new Error(`Failed to retrieve record from ${tableName}`);
+   }
+}
+
+export async function updateRecord<T extends TableEntityMap[TableName]>(
+   tableName: TableName,
+   id: string,
+   updates: Partial<T>
+): Promise<void> {
+   try {
+      await db.table(tableName).update(id, updates);
+   } catch (error) {
+      console.error(`Error updating record ${id} in ${tableName}:`, error);
+      throw new Error(`Failed to update record in ${tableName}`);
+   }
+}
+
+export async function deleteRecord(
+   tableName: TableName,
+   id: string
+): Promise<void> {
+   try {
+      await db.table(tableName).delete(id);
+   } catch (error) {
+      console.error(`Error deleting record ${id} from ${tableName}:`, error);
+      throw new Error(`Failed to delete record from ${tableName}`);
+   }
+}
+
+export async function clearTable(tableName: TableName): Promise<void> {
+   try {
+      await db.table(tableName).clear();
+   } catch (error) {
+      console.error(`Error clearing ${tableName}:`, error);
+      throw new Error(`Failed to clear ${tableName}`);
+   }
+}
+
+// Get product count for OfflineDrawer
+export async function getProductCount(): Promise<number> {
+   try {
+      const products = await db.products.toArray();
+      return products.length;
+   } catch (error) {
+      console.error("Error retrieving product count:", error);
+      throw new Error("Failed to retrieve product count");
+   }
+}
+
+// Export database instance for advanced queries
+export { db };

--- a/src/lib/dexieUtils.tsx
+++ b/src/lib/dexieUtils.tsx
@@ -14,7 +14,7 @@ class FulcrumsDatabase extends Dexie {
          products:
             "productId,productChineseName,productEnglishName,unitPrice,material,hsCode,packing,saved,updatedAt,supplierId,currency",
          suppliers:
-            "supplierId,supplierName,supplierPhoneNumber,supplierAddress,supplierEmail",
+            "supplierId,supplierName,supplierPhone,supplierAddress,supplierEmail",
          clients:
             "clientId,companyName,contactEmail,contactName,contactPhoneNumber,eoriNumber,updatedAt",
       });
@@ -53,7 +53,9 @@ export async function addRecord<T extends TableEntityMap[TableName]>(
 ): Promise<string> {
    try {
       const recordWithId = ensureId(tableName, record);
-      return await db.table(tableName).add(recordWithId) as string;
+      return (await db
+         .table(tableName)
+         .add({ ...recordWithId, upDatedAt: new Date().toString() })) as string;
    } catch (error) {
       console.error(`Error adding record to ${tableName}:`, error);
       throw new Error(`Failed to add record to ${tableName}`);
@@ -140,6 +142,26 @@ export async function getProductCount(): Promise<number> {
    } catch (error) {
       console.error("Error retrieving product count:", error);
       throw new Error("Failed to retrieve product count");
+   }
+}
+
+export async function getSupplierCount(): Promise<number> {
+   try {
+      const suppliers = await db.suppliers.toArray();
+      return suppliers.length;
+   } catch (error) {
+      console.error("Error retrieving supplier count:", error);
+      throw new Error("Failed to retrieve supplier count");
+   }
+}
+
+export async function getClientCount(): Promise<number> {
+   try {
+      const clients = await db.clients.toArray();
+      return clients.length;
+   } catch (error) {
+      console.error("Error retrieving client count:", error);
+      throw new Error("Failed to retrieve client count");
    }
 }
 

--- a/src/lib/dexieUtils.tsx
+++ b/src/lib/dexieUtils.tsx
@@ -55,7 +55,7 @@ export async function addRecord<T extends TableEntityMap[TableName]>(
       const recordWithId = ensureId(tableName, record);
       return (await db
          .table(tableName)
-         .add({ ...recordWithId, upDatedAt: new Date().toString() })) as string;
+         .add({ ...recordWithId, updatedAt: new Date().toString() })) as string;
    } catch (error) {
       console.error(`Error adding record to ${tableName}:`, error);
       throw new Error(`Failed to add record to ${tableName}`);

--- a/src/lib/dexieUtils.tsx
+++ b/src/lib/dexieUtils.tsx
@@ -2,7 +2,6 @@ import Dexie, { Table } from "dexie";
 import { v4 as uuidv4 } from "uuid";
 import { Product, Supplier, Clients } from "../types/types";
 
-// Initialize Dexie database
 class FulcrumsDatabase extends Dexie {
    products!: Table<Product, string>;
    suppliers!: Table<Supplier, string>;
@@ -10,7 +9,8 @@ class FulcrumsDatabase extends Dexie {
 
    constructor() {
       super("FulcrumsDatabase");
-      this.version(1).stores({
+
+      this.version(3).stores({
          products:
             "productId,productChineseName,productEnglishName,unitPrice,material,hsCode,packing,saved,updatedAt,supplierId,currency",
          suppliers:
@@ -23,17 +23,13 @@ class FulcrumsDatabase extends Dexie {
 
 const db = new FulcrumsDatabase();
 
-// Map table names to their corresponding entity types
 type TableEntityMap = {
    products: Product;
    suppliers: Supplier;
    clients: Clients;
 };
-
-// Generic type for table names
 type TableName = keyof TableEntityMap;
 
-// Utility to ensure ID is provided or generated
 function ensureId<T extends TableEntityMap[TableName]>(
    tableName: TableName,
    record: Partial<T>
@@ -57,8 +53,7 @@ export async function addRecord<T extends TableEntityMap[TableName]>(
 ): Promise<string> {
    try {
       const recordWithId = ensureId(tableName, record);
-      return await db.table(tableName).add(recordWithId);
-      
+      return await db.table(tableName).add(recordWithId) as string;
    } catch (error) {
       console.error(`Error adding record to ${tableName}:`, error);
       throw new Error(`Failed to add record to ${tableName}`);
@@ -148,5 +143,4 @@ export async function getProductCount(): Promise<number> {
    }
 }
 
-// Export database instance for advanced queries
 export { db };

--- a/src/pages/dashboard/AddProductPage.tsx
+++ b/src/pages/dashboard/AddProductPage.tsx
@@ -12,7 +12,7 @@ import {
    Stack,
    Popper,
 } from "@mui/material";
-import { Exam, PlusCircle, X } from "phosphor-react";
+import { PlusCircle, X } from "phosphor-react";
 import Nav from "../../components/core/nav";
 import Footer from "../../components/core/footer";
 import SideNav from "../../components/dashboard/dashboardNav";
@@ -28,8 +28,10 @@ import MultipleSelectChip from "../../components/core/multiselectWithChip";
 import getBase64FromBlobUrl from "../../lib/blob-to-blob64";
 import NewSupplierModal from "../../components/dashboard/supplier/addNewSupplierModal";
 import { getSupplierIdByName } from "../../lib/supplierHelpers";
+import { OfflineDrawer } from "../../components/dashboard/core/offlineDrawer";
+import { addRecord } from "../../lib/dexieUtils";
 
-const AddProductForm = () => {
+const AddProductForm = ({ isOnline }: { isOnline: boolean }) => {
    const { navOpen } = useUIStateContext();
    const { isMdUp } = useThemeContext();
 
@@ -102,6 +104,38 @@ const AddProductForm = () => {
       if (!supplierId) {
          console.error(`${supplierId}不是一个供应商ID`);
          setErrorMessages(`${supplierId}不是一个供应商ID`);
+         return;
+      }
+
+      if (!isOnline) {
+         addRecord("products", {
+            image: base64String,
+            productChineseName: productChineseName,
+            productEnglishName: productEnglishName,
+            unitPrice: unitPrice,
+            packing: packing,
+            packingVolume: {
+               length: packingLength,
+               width: packingWidth,
+               height: packingHeight,
+               packingUnit: packingDimensionUnit,
+            },
+            packingMass: {
+               packingMassQuantity: packingMass,
+               packingMassUnit: packingMassUnit,
+            },
+            saved: saved,
+            updatedAt: new Date().toISOString(),
+            supplierId: supplierId,
+            additionalNotes: additionalNotes,
+            clients: selectedClient || [],
+            currency: currency,
+            hsCode: hsCode,
+            material: material,
+         });
+
+         console.log("Product added to IndexedDB");
+         setAddedProduct(true);
          return;
       }
 
@@ -274,7 +308,8 @@ const AddProductForm = () => {
          missing.push("包装尺寸");
       }
       if (!supplierName) missing.push("供应商名称");
-      if (selectedClient?.length === 0 || selectedClient === null) missing.push("客户");
+      if (selectedClient?.length === 0 || selectedClient === null)
+         missing.push("客户");
       if (src === ProductDefaultImage) missing.push("产品图片");
 
       setIsFormComplete(missing.length ? "请填写" + missing.join(", ") : true);
@@ -296,7 +331,7 @@ const AddProductForm = () => {
          setTimeout(() => {
             resetPage();
             setAddedProduct(false);
-            setSubmittingForm(false); 
+            setSubmittingForm(false);
          }, 2000);
       }
    }, [isFormComplete, addedProduct]);
@@ -453,9 +488,7 @@ const AddProductForm = () => {
                      InputProps={{
                         startAdornment: (
                            <InputAdornment position="start">
-                              <IconButton
-                                 color="primary"
-                              >
+                              <IconButton color="primary">
                                  <Typography>{currency}</Typography>
                               </IconButton>
                            </InputAdornment>
@@ -885,6 +918,7 @@ const AddProductForm = () => {
                保存产品
             </Button>
          </Box>
+
          {isFormComplete === true && (
             <button
                onClick={() => handleAddProduct()}
@@ -926,10 +960,14 @@ const AddProductForm = () => {
          )}
 
          <NewClientModal open={isClientModalOpen} onClose={closeClientModal} />
+
          <NewSupplierModal
             open={isSupplierModalOpen}
             onClose={closeSupplierModal}
          />
+
+         <OfflineDrawer isOnline={isOnline} />
+
       </React.Fragment>
    );
 };
@@ -937,6 +975,21 @@ const AddProductForm = () => {
 const AddProductPage = () => {
    const { navOpen, setNavOpen, overlay, closeOverlay, mainContentStyles } =
       useUIStateContext();
+
+   const [isOnline, setIsOnline] = useState(navigator.onLine);
+
+   useEffect(() => {
+      const handleOnline = () => setIsOnline(true);
+      const handleOffline = () => setIsOnline(false);
+
+      window.addEventListener("online", handleOnline);
+      window.addEventListener("offline", handleOffline);
+
+      return () => {
+         window.removeEventListener("online", handleOnline);
+         window.removeEventListener("offline", handleOffline);
+      };
+   }, []);
 
    useEffect(() => {
       document.title = "Fulcrums | 添加产品";
@@ -948,7 +1001,7 @@ const AddProductPage = () => {
 
          <Nav home={false} searchBar={true} />
 
-         <AddProductForm />
+         <AddProductForm isOnline={isOnline} />
 
          <div style={{ padding: "0 16px" }}>
             <Footer />

--- a/src/pages/dashboard/AddProductPage.tsx
+++ b/src/pages/dashboard/AddProductPage.tsx
@@ -172,30 +172,6 @@ const AddProductForm = ({ isOnline }: { isOnline: boolean }) => {
       CNYtoEURO: 0.1269832,
    });
 
-   const toggleCurrency = () => {
-      const base = parseFloat(unitPrice);
-      let converted = 0;
-      let newCurrency = currency;
-      const USDtoEURO = forexRates.CNYtoEURO / forexRates.CNYtoUSD;
-      const EUROtoCNY = 1 / forexRates.CNYtoEURO;
-
-      if (currency === "¥") {
-         // Convert from CNY to USD
-         converted = base * forexRates.CNYtoUSD;
-         newCurrency = "$";
-      } else if (currency === "$") {
-         // Convert from USD to EUR
-         converted = base * USDtoEURO;
-         newCurrency = "€";
-      } else if (currency === "€") {
-         // Convert from EUR to CNY
-         converted = base * EUROtoCNY;
-         newCurrency = "¥";
-      }
-      setUnitPrice(converted.toFixed(2));
-      setCurrency(newCurrency);
-   };
-
    const togglePackingUnit = () => {
       setPackingMassUnit((prev) => (prev === "kg" ? "g" : "kg"));
    };
@@ -959,11 +935,12 @@ const AddProductForm = ({ isOnline }: { isOnline: boolean }) => {
             </Box>
          )}
 
-         <NewClientModal open={isClientModalOpen} onClose={closeClientModal} />
+         <NewClientModal open={isClientModalOpen} onClose={closeClientModal} isOnline={isOnline} />
 
          <NewSupplierModal
             open={isSupplierModalOpen}
             onClose={closeSupplierModal}
+            isOnline={isOnline}
          />
 
          <OfflineDrawer isOnline={isOnline} />

--- a/src/pages/dashboard/addNewClient.tsx
+++ b/src/pages/dashboard/addNewClient.tsx
@@ -12,10 +12,12 @@ import {
    useTheme,
 } from "@mui/material";
 import { useProductSupplierClientContext } from "../../contexts/productSupplierClientContextProvider";
+import { addRecord } from "../../lib/dexieUtils";
 
 interface NewClientModalProps {
    open: boolean;
    onClose: () => void;
+   isOnline: boolean;
 }
 
 export interface ClientForm {
@@ -52,12 +54,25 @@ const fieldMeta: Array<{
    { key: "vatNumber", label: "VAT 增值税号" },
 ];
 
-const NewClientModal: React.FC<NewClientModalProps> = ({ open, onClose }) => {
+const NewClientModal: React.FC<NewClientModalProps> = ({
+   open,
+   onClose,
+   isOnline,
+}) => {
    const theme = useTheme();
    const [form, setForm] = React.useState<ClientForm>(emptyForm);
-   const { addClient } = useProductSupplierClientContext();
+   const { addClient, setErrorMessages } = useProductSupplierClientContext();
 
    const handleSave = () => {
+      if (!isOnline) {
+         addRecord("clients", form);
+
+         setErrorMessages(`添加${form.companyName}成功`);
+         setForm(emptyForm);
+         onClose();
+         return;
+      }
+
       addClient(form);
 
       setForm(emptyForm);

--- a/src/pages/dashboard/displayProductPage.tsx
+++ b/src/pages/dashboard/displayProductPage.tsx
@@ -543,7 +543,7 @@ const AddProductForm = ({ p }: { p: Product }) => {
                      setSupplierName(newValue.supplierName);
                      setSupplierNameInput(newValue.supplierName);
                      setSupplierAddress(newValue.supplierAddress ?? "");
-                     setSupplierPhone(newValue.supplierPhoneNumber ?? "");
+                     setSupplierPhone(newValue.supplierPhone ?? "");
                      setSupplierEmail(newValue.supplierEmail ?? "");
                   }}
                   isOptionEqualToValue={(option, value) =>

--- a/src/pages/dashboard/displayProductPage.tsx
+++ b/src/pages/dashboard/displayProductPage.tsx
@@ -142,8 +142,6 @@ const AddProductForm = ({ p }: { p: Product }) => {
       });
    }
 
-   console.log(p);
-
    async function handleProductDeletion() {
       await deleteProducts([p.productId]);
       return;
@@ -234,7 +232,7 @@ const AddProductForm = ({ p }: { p: Product }) => {
       setSupplierName(supplierDetails.supplierName);
       setSupplierNameInput(supplierDetails.supplierName);
       setSupplierAddress(supplierDetails.supplierAddress ?? "");
-      setSupplierPhone(supplierDetails.supplierPhoneNumber ?? "");
+      setSupplierPhone(supplierDetails.supplierPhone ?? "");
       setSupplierEmail(supplierDetails.supplierEmail ?? "");
    }, [suppliers, p.supplierId]);
    return (

--- a/src/types/types.tsx
+++ b/src/types/types.tsx
@@ -40,7 +40,7 @@ export type Product = {
 export type Supplier = {
    supplierId: string;
    supplierName: string;
-   supplierPhoneNumber: string;
+   supplierPhone: string;
    supplierAddress: string;
    supplierEmail: string;
 };


### PR DESCRIPTION
### Key Features
| Area | What’s new |
|------|------------|
| **Firestore ⇄ Dexie sync** | `syncAll` callable CF (`backend/functions/src/services/syncAll.ts`) pushes local suppliers/clients/products to Firestore and clears Dexie on success. |
| **Offline UI** | `OfflineDrawer` & floating sync button show local counts, error states, and a “Sync to cloud” action. |
| **Dexie helpers** | CRUD, bulk add, counters (`src/lib/dexieUtils.tsx`). |
| **Base64 / MIME safety** | `upload_blob_as_jpg.ts` + `getBase64FromBlobUrl.tsx` now detect & prepend correct `data:image/*` MIME. |
| **Context updates** | `ProductSupplierClientContext` handles Dexie listeners, merge w/ Firestore, sync state (`idle | syncing | done`). |

---

### Refactors / Fixes
* **Supplier phone field** renamed `supplierPhone` (was `supplierPhoneNumber`) to match schema.
* **PDF builder** pulls updated supplier phone key.

---

### TODOs
* Cloud function still defaults unknown raw b64 to **JPEG** — frontend now always sends MIME but we may hard‑fail if missing.
* Need e2e tests for large payload limits (120 products etc.).

resolves issue #11 
@gemini-code-assist review pr


### Details
**Offline this button appears**
<img width="485" alt="Screenshot 2025-05-29 at 10 21 17" src="https://github.com/user-attachments/assets/feddf244-a3cc-46f3-a871-a2ffd20ae458" />

**Expanded offline drawer**
<img width="490" alt="Screenshot 2025-05-29 at 10 23 26" src="https://github.com/user-attachments/assets/1dda67ed-9804-4013-a4b5-9f597bb12d11" />

**If online && item(s) in dexie**
<img width="132" alt="Screenshot 2025-05-29 at 10 23 59" src="https://github.com/user-attachments/assets/5ad1f916-dea1-4fe9-9001-2c406f41dad8" />

Here, I shall consider moving the syncAll button to display across all protected routes so that even if a user is not adding product they will be able to syncAll.



